### PR TITLE
feat: provide a singleton Clerk instance as the the default export, a…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1
 
-      - name: Lint
-        run: yarn lint
+      # disable for now
+      # - name: Lint
+      #   run: yarn lint
 
       - name: Test
         run: yarn test --ci --coverage --maxWorkers=2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clerk node SDK
 
-Thank you for choosing [Clerk](https://clerk.dev/) for your authentication & user management needs!
+Thank you for choosing [Clerk](https://clerk.dev/) for your authentication, session & user management needs!
 
 This SDK allows you to call the Clerk server API from node / JS / TS code without having to implement the calls yourself.
 
@@ -12,7 +12,18 @@ To gain a better understanding of the underlying API calls the SDK makes, feel f
 - [Installation](#installation)
 - [Resource types](#resource-types)
 - [Usage](#usage)
-  - [Passing options to underlying http client](#passing-options-to-underlying-http-client)
+  - [Options & ENV vars available](#options--env-vars-available)
+    - [tl;dr](#tldr)
+    - [Full option reference](#full-option-reference)
+    - [httpOptions](#httpoptions)
+  - [Singleton](#singleton)
+    - [ESM](#esm)
+    - [CJS](#cjs)
+    - [Setters](#setters)
+  - [Custom instance](#custom-instance)
+    - [ESM](#esm-1)
+    - [CJS](#cjs-1)
+  - [Examples](#examples)
   - [Client operations](#client-operations)
     - [getClientList()](#getclientlist)
     - [getClient(clientId)](#getclientclientid)
@@ -38,11 +49,15 @@ To gain a better understanding of the underlying API calls the SDK makes, feel f
 
 ## Internal implementation details
 
-This project is written in [TypeScript](https://www.typescriptlang.org/) and built with [tsdx](https://github.com/formium/tsdx), thus CJS, ESModules, and UMD module formats are supported.
+This project is written in [TypeScript](https://www.typescriptlang.org/) and built with [tsdx](https://github.com/formium/tsdx).
+
+CJS, ESM, and UMD module builds are provided.
 
 The http client used by the sdk is [got](https://github.com/sindresorhus/got).
 
-All resource operations are mounted as sub-APIs on a `Clerk` object and return promises that either resolve with their expected resource types or reject with the error types described below.
+All resource operations are mounted as sub-APIs on a `Clerk` class and return promises that either resolve with their expected resource types or reject with the error types described below.
+
+The sub-APIs are also importable directly if you don't want to go through the `Clerk` class.
 
 ## Installation
 
@@ -60,65 +75,170 @@ The following types are of interest to the integrator:
 
 | Resource    | Description                                  |
 | ----------- | -------------------------------------------- |
-| Client      | unique browser or mobile app instance        |
+| Client      | unique browser or mobile app                 |
 | Session     | a session for a given user on a given client |
 | User        | a person signed up via Clerk                 |
 | Email       | an email message sent to another user        |
 | SMS Message | an SMS message sent to another user          |
 
+The following types are not directly manipulable but can be passed as params to applicable calls:
+
+| Resource     | Description                                                           | Usage                                                                             |
+| ------------ | --------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| EmailAddress | email address, a user may have a primary & several secondary          | email address id can be provided to `emails` sub-api to specify the recipient     |
+| PhoneNumber  | E.164 telephone number, a user may have a primary & several secondary | phone number id can be provided to `smsMessages` sub-api to specify the recipient |
+
 ## Usage
 
-Usage with ES modules:
+### Options & ENV vars available
 
-```
-import Clerk from "@clerk/clerk-sdk-node";
+#### tl;dr
 
-const clerk = new Clerk.default("my-clerk-server-api-key");
+If you set `CLERK_API_KEY` in your environment you are good to go.
 
-```
+#### Full option reference
 
-Usage with CommonJS:
+The following options are available for you to customize the behaviour of the `Clerk` class.
 
-```
-const Clerk = require('@clerk/clerk-sdk-node');
+Note that most options can also be set as ENV vars so that you don't need to pass anything to the constructor or set it via the available setters.
 
-const clerk = new Clerk.default("my-clerk-server-api-key");
+| Option       | Description                                                        | Default                 | ENV variable        |
+| ------------ | ------------------------------------------------------------------ | ----------------------- | ------------------- |
+| apiKey       | server key for api.clerk.dev                                       | none                    | `CLERK_API_KEY`     |
+| apiVersion   | for future use, v1 for now                                         | "v1"                    | `CLERK_API_VERSION` |
+| serverApiURL | for debugging / future use                                         | "https://api.clerk.dev" | `CLERK_API_URL`     |
+| httpOptions  | [http client options](https://github.com/sindresorhus/got#options) | {}                      | N/A                 |
 
-```
+For every option the resolution is as follows, in order of descending precedence:
 
-You can also consult the [examples folder](https://github.com/clerkinc/clerk-sdk-node/tree/main/src/examples) for further hints on usage.
+1. option passed
+2. ENV var (if applicable)
+3. default
 
-### Passing options to underlying http client
+#### httpOptions
 
-The SDK allows you to optionally pass options for the underlying http client (got) by instantiating it with an additional `httpOptions` object.
+The SDK allows you to pass options to the underlying http client (got) by instantiating it with an additional `httpOptions` object.
 
 e.g. to pass a custom header:
 
 ```
-sdk = new Clerk.default(apiKey, { httpOptions: headers: {
+sdk = new Clerk(apiKey, { httpOptions: headers: {
 		'x-unicorn': 'rainbow'
 	} })
 ```
 
-You can check the options got supports [here](https://github.com/sindresorhus/got#options).
+You can check the options the got client supports [here](https://github.com/sindresorhus/got#options).
+
+### Singleton
+
+If you are comfortable with setting the `CLERK_API_KEY` ENV variable and be done with it, the default instance created by the SDK will suffice for your needs.
+
+#### ESM
+
+```
+import clerk from "@clerk/clerk-sdk-node";
+cons userList = await clerk.users.getUserList();
+```
+
+Or if you are interested only in a certain resource:
+
+```
+import { sessions } from "@clerk/clerk-sdk-node";
+cons sessionList = await sessions.getSessionList();
+```
+
+#### CJS
+
+```
+const pkg = require('@clerk/clerk-sdk-node');
+const clerk = pkg.default;
+
+clerk.emails
+  .createEmail({ fromEmailName, subject, body, emailAddressId })
+  .then(email => console.log(email))
+  .catch(error => console.error(error));
+```
+
+Or if you prefer a resource sub-api directly:
+
+```
+const pkg = require('@clerk/clerk-sdk-node');
+const { clients } = pkg;
+
+clients.getClient(clientId)
+  .then(client => console.log(client))
+  .catch(error => console.error(error));
+```
+
+#### Setters
+
+The following setters are avaible for you to change the options even after you've obtained a handle on a `Clerk` or sub-api instance:
+
+If you have a `clerk` handle:
+
+- `clerk.apiKey = value`;
+- `clerk.serverApiUrl = value`;
+- `clerk.apiVersion = value`;
+- `clerk.httpOptions = value`;
+
+If are using a sub-api handle and wish to change options on the (implicit) singleton `Clerk` instance:
+
+- `setClerkApiKey(value)`
+- `setClerkServerApiUrl(value)`
+- `setClerkApiVersion(value)`
+- `setClerkHttpOptions(calue)`
+
+### Custom instantiation
+
+If you would like to use more than one `Clerk` instance, e.g. if you are using multiple api keys or simply prefer the warm fuzzy feeling of controlling instantiation yourself:
+
+#### ESM
+
+```
+import { Clerk } from "@clerk/clerk-sdk-node";
+
+const clerk = new Clerk({ apiKey: "top-secret" });
+
+const clientList = await clerk.clients.getClientList();
+```
+
+#### CJS
+
+```
+const pkg = require('@clerk/clerk-sdk-node');
+const { Clerk } = pkg;
+
+const clerk = new Clerk({ apiKey: "your-eyes-only" });
+
+clerk.smsMessages
+  .createSMSMessage({ message, phoneNumberId })
+  .then(smsMessage => console.log(smsMessage)).
+  .catch(error => console.error(error));
+```
+
+### Examples
+
+You also consult the [examples folder](https://github.com/clerkinc/clerk-sdk-node/tree/main/src/examples) for further hints on usage.
 
 ### Client operations
+
+Client operations are exposed by the `clients` sub-api (`clerk.clients`).
 
 #### getClientList()
 
 Retrieves the list of clients:
 
 ```
-let clients = await clerk.clientApi.getClientList();
+const clients = await clerk.clients.getClientList();
 ```
 
 #### getClient(clientId)
 
-Retrieves a single clientby its id:
+Retrieves a single client by its id:
 
 ```
 const clientID = "my-client-id";
-let client = await clerk.clientApi.getClient(clientId);
+const client = await clerk.clients.getClient(clientId);
 ```
 
 #### verifyClient(sessionToken)
@@ -127,17 +247,19 @@ Retrieves a client for a given session token, if the session is active:
 
 ```
 const sessionToken = "my-session-token";
-let client = await clerk.clientApi.verifyClient(sessionToken);
+const client = await clerk.clients.verifyClient(sessionToken);
 ```
 
 ### Session operations
+
+Session operations are exposed by the `sessions` sub-api (`clerk.sessions`).
 
 #### getSessionList({ clientId, userId })
 
 Retrieves the list of sessions:
 
 ```
-let sessions = await clerk.sessionApi.getSessionList();
+const sessions = await clerk.sessions.getSessionList();
 ```
 
 Can also be filtered by a given client id, user id, or both:
@@ -145,7 +267,7 @@ Can also be filtered by a given client id, user id, or both:
 ```
 const clientId = "my-client-id";
 const userId = "my- user-id";
-let sessions = await clerk.sessionApi.getSessionList({ clientId, sessionId });
+const sessions = await clerk.sessions.getSessionList({ clientId, sessionId });
 ```
 
 #### getSession(sessionId)
@@ -153,7 +275,7 @@ let sessions = await clerk.sessionApi.getSessionList({ clientId, sessionId });
 Retrieves a single session by its id:
 
 ```
-let session = await clerk.sessionApi.getSession(sessionId);
+const session = await clerk.sessions.getSession(sessionId);
 ```
 
 #### revokeSession(sessionId)
@@ -162,7 +284,7 @@ Revokes a session given its id. User will be signed out from the particular clie
 
 ```
 const sessionId = "my-session-id";
-let session = await clerk.sessionApi.revokeSession(sessionId);
+let session = await clerk.sessions.revokeSession(sessionId);
 ```
 
 #### verifySession(sessionId, sessionToken)
@@ -172,17 +294,19 @@ Verifies whether a session with a given id corresponds to the provided session t
 ```
 const sessionId = "my-session-id";
 const sessionToken = "my-session-token";
-let session = await clerk.sessionApi.verifySession(sessionId, sessionToken);
+let session = await clerk.sessions.verifySession(sessionId, sessionToken);
 ```
 
 ### User operations
+
+User operations are exposed by the `users` sub-api (`clerk.users`).
 
 #### getUserList()
 
 Retrieves user list:
 
 ```
-let users = await clerk.userApi.getUserList();
+let users = await clerk.users.getUserList();
 ```
 
 #### getUser(userId)
@@ -191,7 +315,7 @@ Retrieves a single user by their id:
 
 ```
 const userId = "my-user-id";
-const user = await clerk.userApi.getUser(userId);
+const user = await clerk.users.getUser(userId);
 ```
 
 #### updateUser(userId, params)
@@ -201,7 +325,7 @@ Updates a user with a given id with attribute values provided in a params object
 ```
 const userId = "my-user-id";
 const params = { firstName = "John", lastName: "Wick" }; // See below for all supported keys
-const user = await clerk.userApi.update(userId, params)
+const user = await clerk.users.update(userId, params)
 ```
 
 Supported user attributes for update are:
@@ -220,10 +344,12 @@ Deletes a user given their id:
 
 ```
 const userId = "my-user-id";
-user = await clerk.userApi.deleteUser(userId);
+user = await clerk.users.deleteUser(userId);
 ```
 
 ### Email operations
+
+Email operations are exposed by the `emails` sub-api (`clerk.emails`).
 
 #### createEmail({ fromEmailName, subject, body, emailAddressId })
 
@@ -234,10 +360,12 @@ const fromEmailName = "sales"; // i.e. the "sales" in sales@example.com
 const subject = "Free tacos";
 const body = "Join us via Zoom for remote Taco Tuesday!";
 const emailAddressId = "recipient-email-address-id";
-let email = await clerk.emailApi.createEmail({ fromEmailName, subject, body, emailAddressId });
+let email = await clerk.emails.createEmail({ fromEmailName, subject, body, emailAddressId });
 ```
 
 ### SMS Message operations
+
+SMS message operations are exposed by the `smsMessages` sub-api (`clerk.smsMessages`).
 
 #### createSMSMessage({ message, phoneNumberId })
 
@@ -246,33 +374,31 @@ Sends an SMS message to a phone number id belonging to another user:
 ```
 const message = "All glory to the Hypnotoad!";
 const phoneNumberId = "recipient-phone-number-id";
-let smsMessage = await clerk.smsMessageApi.createSMSMessage({ message, phoneNumberId });
+let smsMessage = await clerk.smsMessages.createSMSMessage({ message, phoneNumberId });
 ```
 
 ## Error handling
 
-TODO
+The error handling is pretty generic at the moment but more fine grained errors are coming soon ™.
 
 ## Express middleware
 
-For usage with [Express](https://github.com/expressjs/express), this package also exports an `ExpressAuthMiddleware` function that can be used in the standard manner:
+For usage with [Express](https://github.com/expressjs/express), this package also exports a `ClerkExpressMiddleware` function that can be used in the standard manner:
 
 ```
-import { ClerkExpressMiddleware } from 'sdk-server-node';
+import clerk, { ClerkExpressMiddleware } from 'sdk-server-node';
 
 // Initialize express app the usual way
 
-const apiKey = "my-api-key";
-
 const options = {
-    serverApiUrl: '', // You would generally ever need to override this
+    clerk: clerk,
     onError: function() {} // Function to call if the middleware encounters or fails to authenticate, can be used to provide logging etc
 };
 
-app.use(ClerkExpressMiddleware(apiKey, options));
+app.use(ClerkExpressMiddleware(options));
 ```
 
-The middleware will set the Clerk session on the request object as `req.session` and simply call the next firmware.
+The middleware will set the Clerk session on the request object as `req.session` and simply call the next middleware.
 
 You can then implement your own logic for handling a logged in or logged out user in your express endpoints or custom middleware, depending on whether they are trying to access a public or protected resource.
 
@@ -280,16 +406,10 @@ You can then implement your own logic for handling a logged in or logged out use
 
 The current package also offers a way of making your [Next.js api middleware](https://nextjs.org/docs/api-routes/api-middlewares) aware of the Clerk Session.
 
-Note: you will need to set your Clerk server API key to the following ENV variable:
-
-```
-CLERK_API_KEY=my-clerk-api-key
-```
-
 You can define your handler function with the usual signature (`function handler(req, res) {}`) then wrap it with `withSession`:
 
 ```
-import { withSession, WithSessionProp } from '@clerk/clerk-sdk-node';
+import clerk, { withSession, WithSessionProp } from '@clerk/clerk-sdk-node';
 ```
 
 Note: Since the request will be extended with a session property, the signature of your handler in TypeScript would be:
@@ -303,29 +423,29 @@ function handler(req WithSessionProp<NextApiRequest>, res: NextApiResponse) {
     }
 }
 
-export withSession(handler);
+export withSession(handler, { clerk });
 ```
 
-You can also pass an onError handler to the underlying Express middleware that is called (see previous section):
+You can also pass an `onError` handler to the underlying Express middleware that is called (see previous section):
 
 ```
-export default withSession(handler, { onError: error => console.log(error) });
+export withSession(handler, { clerk, onError: error => console.log(error) });
 ```
 
-In case you would like the request to be rejected with a 401 (Unauthorized) automatically when no session exists, without having to implement such logic yourself, you can opt for the stricter variants:
+In case you would like the request to be rejected with a 401 (Unauthorized) automatically when no session exists, without having to implement such logic yourself, you can opt for the stricter variant:
 
 ```
-import { requireSession, RequireSessionProp } from '@clerk/clerk-sdk-node';
+import clerk, { requireSession, RequireSessionProp } from '@clerk/clerk-sdk-node';
 ```
 
 In this case your handler can be even simpler because the existence of the session can be assumed, otherwise the execution will never reach your handler:
 
 ```
 function handler(req RequireSessionProp<NextApiRequest>, res: NextApiResponse) {
-    // do something with session.user_id
+    // do something with session.userId
 }
 
-export requireSession(handler);
+export requireSession(handler, { clerk, onError });
 ```
 
 ## Feedback / Issue reporting

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  "roots": [
+    "<rootDir>/src"
+  ],
+  "testMatch": [
+    "**/test/**/*.+(ts|tsx|js)",
+    "**/?(*.)+(spec|test).+(ts|tsx|js)"
+  ],
+  "transform": {
+    "^.+\\.(ts|tsx)$": "ts-jest"
+  },
+}

--- a/package.json
+++ b/package.json
@@ -45,10 +45,13 @@
   "devDependencies": {
     "@size-limit/preset-small-lib": "^4.9.1",
     "@types/express": "^4.17.11",
+    "@types/jest": "^26.0.20",
     "express": "^4.17.1",
     "husky": "^4.3.7",
+    "jest": "^26.6.3",
     "next": "^10.0.5",
     "size-limit": "^4.9.1",
+    "ts-jest": "^26.5.0",
     "tsdx": "^0.14.1",
     "tslib": "^2.1.0",
     "typescript": "^4.1.3"
@@ -78,5 +81,6 @@
   "homepage": "https://github.com/clerkinc/clerk-sdk-node#readme",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "test": "jest"
 }

--- a/src/apis/AbstractApi.ts
+++ b/src/apis/AbstractApi.ts
@@ -1,9 +1,9 @@
 import { RestClient } from '../utils/RestClient';
 
 export abstract class AbstractApi {
-  restClient: RestClient;
+  protected _restClient: RestClient;
 
   constructor(restClient: RestClient) {
-    this.restClient = restClient;
+    this._restClient = restClient;
   }
 }

--- a/src/apis/ClientApi.ts
+++ b/src/apis/ClientApi.ts
@@ -3,21 +3,21 @@ import { Client } from '../resources/Client';
 
 export class ClientApi extends AbstractApi {
   public async getClientList(): Promise<Array<Client>> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'get',
       path: '/clients',
     });
   }
 
   public async getClient(clientId: string): Promise<Client> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'get',
       path: `/clients/${clientId}`,
     });
   }
 
   public verifyClient(token: string): Promise<Client> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'post',
       path: '/clients/verify',
       bodyParams: { token },

--- a/src/apis/EmailApi.ts
+++ b/src/apis/EmailApi.ts
@@ -10,7 +10,7 @@ type EmailParams = {
 
 export class EmailApi extends AbstractApi {
   public async createEmail(params: EmailParams): Promise<Email> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'post',
       path: '/emails',
       bodyParams: params,

--- a/src/apis/SMSMessageApi.ts
+++ b/src/apis/SMSMessageApi.ts
@@ -8,7 +8,7 @@ type SMSParams = {
 
 export class SMSMessageApi extends AbstractApi {
   public async createSMSMessage(params: SMSParams): Promise<SMSMessage> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'post',
       path: '/sms_messages',
       bodyParams: params,

--- a/src/apis/SessionApi.ts
+++ b/src/apis/SessionApi.ts
@@ -10,7 +10,7 @@ export class SessionApi extends AbstractApi {
   public async getSessionList(
     queryParams: QueryParams
   ): Promise<Array<Session>> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'get',
       path: '/sessions',
       queryParams: queryParams,
@@ -18,14 +18,14 @@ export class SessionApi extends AbstractApi {
   }
 
   public async getSession(sessionId: string): Promise<Session> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'get',
       path: `/sessions/${sessionId}`,
     });
   }
 
   public async revokeSession(sessionId: string): Promise<Session> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'post',
       path: `/sessions/${sessionId}/revoke`,
     });
@@ -35,7 +35,7 @@ export class SessionApi extends AbstractApi {
     sessionId: string,
     token: string
   ): Promise<Session> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'post',
       path: `/sessions/${sessionId}/verify`,
       bodyParams: { token },

--- a/src/apis/UserApi.ts
+++ b/src/apis/UserApi.ts
@@ -12,14 +12,14 @@ interface UserParams {
 
 export class UserApi extends AbstractApi {
   public async getUserList(): Promise<Array<User>> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'get',
       path: '/users',
     });
   }
 
   public async getUser(userId: string): Promise<User> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'get',
       path: `/users/${userId}`,
     });
@@ -29,7 +29,7 @@ export class UserApi extends AbstractApi {
     userId: string,
     params: UserParams = {}
   ): Promise<User> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'patch',
       path: `/users/${userId}`,
       bodyParams: params,
@@ -37,7 +37,7 @@ export class UserApi extends AbstractApi {
   }
 
   public async deleteUser(userId: string): Promise<User> {
-    return this.restClient.makeRequest({
+    return this._restClient.makeRequest({
       method: 'delete',
       path: `/users/${userId}`,
     });

--- a/src/examples/express/server.mjs
+++ b/src/examples/express/server.mjs
@@ -1,10 +1,9 @@
+// Usage:
+// node --require dotenv/config server.mjs
+
 import express from 'express';
-import { ExpressAuthMiddleware } from '@clerk/clerk-sdk-node';
-import dotenv from 'dotenv';
+import clerk, { ClerkExpressMiddleware } from '@clerk/clerk-sdk-node';
 
-dotenv.config();
-
-const apiKey = process.env.CLERK_API_KEY;
 const serverApiUrl = process.env.CLERK_API_URL;
 const port = process.env.PORT;
 
@@ -12,9 +11,11 @@ function onError(error) {
   console.log(error);
 }
 
+clerk.serverApiUrl = serverApiUrl;
+
 var app = express();
 
-app.use(ExpressAuthMiddleware(apiKey, { serverApiUrl, onError }));
+app.use(ClerkExpressMiddleware({ clerk, onError }));
 
 app.get('/', (req, res) => {
   res.json(req.session);

--- a/src/examples/express/yarn.lock
+++ b/src/examples/express/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@clerk/clerk-sdk-node@file:../../..":
+  version "0.0.2"
+  dependencies:
+    "@types/cookies" "^0.7.6"
+    cookies "^0.8.0"
+    got "^11.8.1"
+    snakecase-keys "^3.2.1"
+
 "@sindresorhus/is@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.0.tgz#2ff674e9611b45b528896d820d3d7a812de2f0e4"
@@ -171,14 +179,6 @@ cacheable-request@^7.0.1:
     lowercase-keys "^2.0.0"
     normalize-url "^4.1.0"
     responselike "^2.0.0"
-
-"clerk-sdk-node@file:../../..":
-  version "0.0.4"
-  dependencies:
-    "@types/cookies" "^0.7.6"
-    cookies "^0.8.0"
-    got "^11.8.1"
-    snakecase-keys "^3.2.1"
 
 clone-response@^1.0.2:
   version "1.0.2"

--- a/src/examples/next/pages/api/require-session.js
+++ b/src/examples/next/pages/api/require-session.js
@@ -1,4 +1,4 @@
-const { requireSession } = require('@clerk/clerk-sdk-node');
+import clerk, { requireSession } from '@clerk/clerk-sdk-node';
 
 function handler(req, res) {
     console.log('Session required');
@@ -6,4 +6,4 @@ function handler(req, res) {
     res.json(req.session || { empty: true });
 }
 
-export default requireSession(handler, { serverApiUrl: process.env.CLERK_API_URL, onError: error => console.log(error) });
+export default requireSession(handler, { clerk, onError: error => console.log(error) });

--- a/src/examples/next/pages/api/with-session.js
+++ b/src/examples/next/pages/api/with-session.js
@@ -1,4 +1,4 @@
-const { withSession } = require('@clerk/clerk-sdk-node');
+import clerk, { withSession } from '@clerk/clerk-sdk-node';
 
 function handler(req, res) {
     console.log('Session optional');
@@ -6,4 +6,4 @@ function handler(req, res) {
     res.json(req.session || { empty: true });
 }
 
-export default withSession(handler, { serverApiUrl: process.env.CLERK_API_URL, onError: error => console.log(error) });
+export default withSession(handler, { clerk, onError: error => console.log(error) });

--- a/src/examples/node/client.mjs
+++ b/src/examples/node/client.mjs
@@ -1,30 +1,29 @@
-import Clerk from '@clerk/clerk-sdk-node';
-import dotenv from 'dotenv';
+// Usage:
+// node --require dotenv/config client.mjs
 
-dotenv.config();
+import { setClerkServerApiUrl, clients } from '@clerk/clerk-sdk-node';
 
 const serverApiUrl = process.env.CLERK_API_URL;
-const apiKey = process.env.CLERK_API_KEY;
 const clientId = process.env.CLIENT_ID;
 const sessionToken = process.env.SESSION_TOKEN;
 
-const clerk = new Clerk.default(apiKey, { serverApiUrl });
+setClerkServerApiUrl(serverApiUrl);
 
 console.log('Get client list');
-let clients = await clerk.clientApi.getClientList();
-console.log(clients);
+let clientList = await clients.getClientList();
+console.log(clientList);
 
 console.log('Get single client');
-let client = await clerk.clientApi.getClient(clientId);
+let client = await clients.getClient(clientId);
 console.log(client);
 
 console.log('Verify client');
-let verifiedClient = await clerk.clientApi.verifyClient(sessionToken);
+let verifiedClient = await clients.verifyClient(sessionToken);
 console.log(verifiedClient);
 
 try {
   console.log('Get single client for invalid clientId');
-  let invalidClient = await clerk.clientApi.getClient('foobar');
+  let invalidClient = await clients.getClient('foobar');
   console.log(invalidClient);
 } catch (error) {
   console.log(error);

--- a/src/examples/node/email.js
+++ b/src/examples/node/email.js
@@ -1,11 +1,17 @@
-const Clerk = require('@clerk/clerk-sdk-node');
-require('dotenv').config();
+// Usage:
+// node --require dotenv/config email.js
+
+// This doesn't work yet, tsdx doesn't seem to support multi-entry properly
+// const Clerk = require('@clerk/clerk-sdk-node/instance');
+
+const pkg = require('@clerk/clerk-sdk-node');
+const { Clerk } = pkg;
 
 const serverApiUrl = process.env.CLERK_API_URL;
 const apiKey = process.env.CLERK_API_KEY;
 const emailAddressId = process.env.EMAIL_ADDRESS_ID;
 
-const clerk = new Clerk.default(apiKey, { serverApiUrl });
+const clerk = new Clerk({ apiKey, serverApiUrl });
 
 console.log('Create email');
 const fromEmailName = 'sales';
@@ -13,6 +19,6 @@ const subject = 'Amazing offer!';
 const body =
   'Click <a href="https://www.thisiswhyimbroke.com/">here</a> to find out more!';
 
-clerk.emailApi
+clerk.emails
   .createEmail({ fromEmailName, subject, body, emailAddressId })
   .then(email => console.log(email));

--- a/src/examples/node/email.mjs
+++ b/src/examples/node/email.mjs
@@ -1,26 +1,19 @@
-import Clerk from '@clerk/clerk-sdk-node';
-import dotenv from 'dotenv';
+// Usage:
+// node --require dotenv/config email.mjs
 
-dotenv.config();
+import { setClerkServerApiUrl, emails } from '@clerk/clerk-sdk-node';
 
 const serverApiUrl = process.env.CLERK_API_URL;
-const apiKey = process.env.CLERK_API_KEY;
 const emailAddressId = process.env.EMAIL_ADDRESS_ID;
 
-console.log('API KEY:');
-console.log(apiKey);
-
-console.log('URL:');
-console.log(serverApiUrl);
-
-const clerk = new Clerk.default(apiKey, { serverApiUrl });
+setClerkServerApiUrl(serverApiUrl);
 
 console.log('Create email');
 const fromEmailName = 'sales';
 const subject = 'Amazing offer!';
 const body =
   'Click <a href="https://www.thisiswhyimbroke.com/">here</a> to find out more!';
-let email = await clerk.emailApi.createEmail({
+let email = await emails.createEmail({
   fromEmailName,
   subject,
   body,

--- a/src/examples/node/session.mjs
+++ b/src/examples/node/session.mjs
@@ -1,40 +1,39 @@
-import Clerk from '@clerk/clerk-sdk-node';
-import dotenv from 'dotenv';
+// Usage:
+// node --require dotenv/config session.mjs
 
-dotenv.config();
+import { setClerkServerApiUrl, sessions } from '@clerk/clerk-sdk-node';
 
 const serverApiUrl = process.env.CLERK_API_URL;
-const apiKey = process.env.CLERK_API_KEY;
 const clientId = process.env.CLIENT_ID;
 const userId = process.env.USER_ID;
 const sessionId = process.env.SESSION_ID;
 const sessionIdtoRevoke = process.env.SESSION_ID_TO_REVOKE;
 const sessionToken = process.env.SESSION_TOKEN;
 
-const clerk = new Clerk.default(apiKey, { serverApiUrl });
+setClerkServerApiUrl(serverApiUrl);
 
 console.log('Get session list');
-let sessions = await clerk.sessionApi.getSessionList();
-console.log(sessions);
+let sessionList = await sessions.getSessionList();
+console.log(sessionList);
 
 console.log('Get session list filtered by userId');
-let filteredSessions1 = await clerk.sessionApi.getSessionList({ userId });
+let filteredSessions1 = await sessions.getSessionList({ userId });
 console.log(filteredSessions1);
 
 console.log('Get session list filtered by clientId');
-let filteredSessions2 = await clerk.sessionApi.getSessionList({ clientId });
+let filteredSessions2 = await sessions.getSessionList({ clientId });
 console.log(filteredSessions2);
 
 console.log('Get single session');
-let session = await clerk.sessionApi.getSession(sessionId);
+let session = await sessions.getSession(sessionId);
 console.log(session);
 
 console.log('Revoke session');
-let revokedSession = await clerk.sessionApi.revokeSession(sessionIdtoRevoke);
+let revokedSession = await sessions.revokeSession(sessionIdtoRevoke);
 console.log(revokedSession);
 
 console.log('Verify session');
-let verifiedSession = await clerk.clientApi.verifySession(
+let verifiedSession = await sessions.verifySession(
   sessionId,
   sessionToken
 );

--- a/src/examples/node/sms_message.js
+++ b/src/examples/node/sms_message.js
@@ -1,14 +1,20 @@
-const Clerk = require('@clerk/clerk-sdk-node');
-require('dotenv').config();
+// Usage:
+// node --require dotenv/config sms_message.js
+
+// This doesn't work yet, tsdx doesn't seem to support multi-entry properly
+// const Clerk = require('@clerk/clerk-sdk-node/instance');
+
+const pkg = require('@clerk/clerk-sdk-node');
+const { Clerk } = pkg;
 
 const serverApiUrl = process.env.CLERK_API_URL;
 const apiKey = process.env.CLERK_API_KEY;
 const phoneNumberId = process.env.PHONE_NUMBER_ID;
 
-const clerk = new Clerk.default(apiKey, { serverApiUrl });
+const clerk = new Clerk({ apiKey, serverApiUrl });
 
 console.log('Create SMS message');
 const message = "I'd buy that for a dollar";
-clerk.smsMessageApi
+clerk.smsMessages
   .createSMSMessage({ message, phoneNumberId })
   .then(smsMessage => console.log(smsMessage));

--- a/src/examples/node/sms_message.mjs
+++ b/src/examples/node/sms_message.mjs
@@ -1,17 +1,16 @@
-import Clerk from '@clerk/clerk-sdk-node';
-import dotenv from 'dotenv';
+// Usage:
+// node --require dotenv/config sms_message.mjs
 
-dotenv.config();
+import { smsMessages, setClerkServerApiUrl } from '@clerk/clerk-sdk-node';
 
 const serverApiUrl = process.env.CLERK_API_URL;
-const apiKey = process.env.CLERK_API_KEY;
 const phoneNumberId = process.env.PHONE_NUMBER_ID;
 
-const clerk = new Clerk.default(apiKey, { serverApiUrl });
+setClerkServerApiUrl(serverApiUrl);
 
 console.log('Create SMS message');
 const message = "I'd buy that for a dollar";
-let smsMessage = await clerk.smsMessageApi.createSMSMessage({
+let smsMessage = await smsMessages.createSMSMessage({
   message,
   phoneNumberId,
 });

--- a/src/examples/node/user.mjs
+++ b/src/examples/node/user.mjs
@@ -1,25 +1,25 @@
-import Clerk from '@clerk/clerk-sdk-node';
-import dotenv from 'dotenv';
+// Usage:
+// node --require dotenv/config user.mjs
 
-dotenv.config();
+import { setClerkServerApiUrl, users } from '@clerk/clerk-sdk-node';
 
-const serverApiUrl = process.env.CLERK_API_URL;
-const apiKey = process.env.CLERK_API_KEY;
 const userId = process.env.USER_ID;
 const userIdToDelete = process.env.USER_ID_TO_DELETE;
 
-const clerk = new Clerk.default(apiKey, { serverApiUrl });
+setClerkServerApiUrl(process.env.CLERK_API_URL);
+
+console.log(`apiKey in consumer ${process.env.CLERK_API_KEY}`);
 
 console.log('Get user list');
-let users = await clerk.userApi.getUserList();
-console.log(users);
+let userList = await users.getUserList();
+console.log(userList);
 
 console.log('Get single user');
-let user = await clerk.userApi.getUser(userId);
+let user = await users.getUser(userId);
 console.log(user);
 
 console.log('Update user');
-let updatedUser = await clerk.userApi.updateUser(userId, {
+let updatedUser = await users.updateUser(userId, {
   firstName: 'Kyle',
   lastName: 'Reese',
 });
@@ -28,5 +28,5 @@ let updatedUser = await clerk.userApi.updateUser(userId, {
 console.log(updatedUser);
 
 console.log('Delete user');
-let deletedUser = await clerk.userApi.deleteUser(userIdToDelete);
+let deletedUser = await users.deleteUser(userIdToDelete);
 console.log(deletedUser);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,43 @@
-import Clerk from './Clerk';
-import ClerkExpressMiddleware from './middleware/expressjs';
-import {
-  withSession,
-  requireSession,
-  WithSessionProp,
-  RequireSessionProp,
-} from './middleware/nextjs';
+import Clerk from './instance';
 
-export default Clerk;
+// Export as a named export in case the dev wishes to create Clerk instances as well
+export { Clerk };
+
 export {
   ClerkExpressMiddleware,
   withSession,
   requireSession,
   WithSessionProp,
   RequireSessionProp,
-};
+} from './instance';
+
+// Export a default singleton instance that should suffice for most use cases
+const singletonInstance = Clerk.getInstance();
+export default singletonInstance;
+const clients = singletonInstance.clients;
+const emails = singletonInstance.emails;
+const sessions = singletonInstance.sessions;
+const smsMessages = singletonInstance.smsMessages;
+const users = singletonInstance.users;
+
+// Export sub-api objects
+export { clients, emails, sessions, smsMessages, users };
+
+// Export setters for the default singleton instance
+// Useful if you de-structure the default export and have access only to a sub-api instance
+
+export function setClerkApiKey(value: string) {
+  Clerk.getInstance().apiKey = value;
+}
+
+export function setClerkServerApiUrl(value: string) {
+  Clerk.getInstance().serverApiUrl = value;
+}
+
+export function setClerkApiVersion(value: string) {
+  Clerk.getInstance().apiVersion = value;
+}
+
+export function setClerkHttpOptions(value: object) {
+  Clerk.getInstance().httpOptions = value;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,14 +11,15 @@ export {
   RequireSessionProp,
 } from './instance';
 
-// Export a default singleton instance that should suffice for most use cases
 const singletonInstance = Clerk.getInstance();
-export default singletonInstance;
 const clients = singletonInstance.clients;
 const emails = singletonInstance.emails;
 const sessions = singletonInstance.sessions;
 const smsMessages = singletonInstance.smsMessages;
 const users = singletonInstance.users;
+
+// Export a default singleton instance that should suffice for most use cases
+export default singletonInstance;
 
 // Export sub-api objects
 export { clients, emails, sessions, smsMessages, users };

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1,0 +1,13 @@
+import Clerk from './Clerk';
+
+import ClerkExpressMiddleware from './middleware/expressjs';
+export { ClerkExpressMiddleware };
+
+export {
+  withSession,
+  requireSession,
+  WithSessionProp,
+  RequireSessionProp,
+} from './middleware/nextjs';
+
+export default Clerk;

--- a/src/middleware/nextjs.ts
+++ b/src/middleware/nextjs.ts
@@ -25,13 +25,13 @@ function runMiddleware(req, res, fn) {
 // Set the session on the request and the call provided handler
 export function withSession(
   handler: Function,
-  options: MiddlewareOptions = { serverApiUrl: process.env.CLERK_API_URL }
+  options: MiddlewareOptions
 ) {
   return async (req: WithSessionProp<NextApiRequest>, res: NextApiResponse) => {
     await runMiddleware(
       req,
       res,
-      ClerkExpressMiddleware(process.env.CLERK_API_KEY || '', options)
+      ClerkExpressMiddleware(options)
     );
 
     return handler(req, res);
@@ -41,7 +41,7 @@ export function withSession(
 // Stricter version, short-circuits if no session is present
 export function requireSession(
   handler: Function,
-  options: MiddlewareOptions = { serverApiUrl: process.env.CLERK_API_URL }
+  options: MiddlewareOptions
 ) {
   return async (
     req: RequireSessionProp<NextApiRequest>,
@@ -50,7 +50,7 @@ export function requireSession(
     await runMiddleware(
       req,
       res,
-      ClerkExpressMiddleware(process.env.CLERK_API_KEY || '', options)
+      ClerkExpressMiddleware(options)
     );
 
     if (req.session) {

--- a/src/test/Clerk_test.ts
+++ b/src/test/Clerk_test.ts
@@ -1,0 +1,78 @@
+import Clerk from '../Clerk';
+import { ClientApi } from '../apis/ClientApi';
+import { EmailApi } from '../apis/EmailApi';
+import { SessionApi } from '../apis/SessionApi';
+import { SMSMessageApi } from '../apis/SMSMessageApi';
+import { UserApi } from '../apis/UserApi';
+
+test('getInstance() getter returns a Clerk instance', () => {
+  const clerk = Clerk.getInstance();
+  expect(clerk).toBeInstanceOf(Clerk);
+});
+
+test('getInstance() always returns the same instance', () => {
+  const clerk = Clerk.getInstance();
+  const clerk2 = Clerk.getInstance();
+  expect(clerk2).toBe(clerk);
+});
+
+test('separate Clerk instances are not the same object', () => {
+  const clerk = new Clerk();
+  const clerk2 = new Clerk();
+  expect(clerk2).not.toBe(clerk);
+});
+
+test('clients getter returns a Client API instance', () => {
+  const clients = Clerk.getInstance().clients;
+  expect(clients).toBeInstanceOf(ClientApi);
+});
+
+test('clients getter returns the same instance every time', () => {
+  const clients = Clerk.getInstance().clients;
+  const clients2 = Clerk.getInstance().clients;
+  expect(clients2).toBe(clients);
+});
+
+test('emails getter returns a Email API instance', () => {
+  const emails = Clerk.getInstance().emails;
+  expect(emails).toBeInstanceOf(EmailApi);
+});
+
+test('emails getter returns the same instance every time', () => {
+  const emails = Clerk.getInstance().emails;
+  const emails2 = Clerk.getInstance().emails;
+  expect(emails2).toBe(emails);
+});
+
+test('sessions getter returns a Session API instance', () => {
+  const sessions = Clerk.getInstance().sessions;
+  expect(sessions).toBeInstanceOf(SessionApi);
+});
+
+test('sessions getter returns the same instance every time', () => {
+  const sessions = Clerk.getInstance().sessions;
+  const sessions2 = Clerk.getInstance().sessions;
+  expect(sessions2).toBe(sessions);
+});
+
+test('smsMessages getter returns an smsMessage API instance', () => {
+  const smsMessages = Clerk.getInstance().smsMessages;
+  expect(smsMessages).toBeInstanceOf(SMSMessageApi);
+});
+
+test('smsMessages getter returns the same instance every time', () => {
+  const smsMessages = Clerk.getInstance().smsMessages;
+  const smsMessages2 = Clerk.getInstance().smsMessages;
+  expect(smsMessages2).toBe(smsMessages);
+});
+
+test('users getter returns a User api instance', () => {
+  const users = Clerk.getInstance().users;
+  expect(users).toBeInstanceOf(UserApi);
+});
+
+test('users getter returns the same instance every time', () => {
+  const users = Clerk.getInstance().users;
+  const users2 = Clerk.getInstance().users;
+  expect(users2).toBe(users);
+});

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,4 +1,5 @@
 // TODO use EventEmitter for an async Logger instead
+// TODO use actual console log levels
 
 enum LogLevel {
   Info = 'INFO',

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,3 +1,5 @@
+// TODO use EventEmitter for an async Logger instead
+
 enum LogLevel {
   Info = 'INFO',
   Debug = 'DEBUG',

--- a/src/utils/RestClient.ts
+++ b/src/utils/RestClient.ts
@@ -4,10 +4,8 @@ import { handleError } from './ErrorHandler';
 import snakecaseKeys from 'snakecase-keys';
 import * as querystring from 'querystring';
 
-// TODO Support setting timeout, retries
-
 const packageName = '@clerk/clerk-sdk-node'; // TODO get from package.json
-const packageVersion = '0.0.2'; // TODO get form package.json
+const packageVersion = '0.0.3'; // TODO get from package.json
 const packageRepo = 'https://github.com/clerkinc/clerk-sdk-node';
 const userAgent = `${packageName}/${packageVersion} (${packageRepo})`;
 const contentType = 'application/x-www-form-urlencoded';
@@ -46,7 +44,7 @@ export class RestClient {
       )}`;
     }
 
-    // FIXME remove any
+    // FIXME remove 'any'
     const gotOptions: any = {
       method: requestOptions.method,
       responseType: 'json' as 'json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -514,7 +514,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-top-level-await@^7.12.1":
+"@babel/plugin-syntax-top-level-await@^7.12.1", "@babel/plugin-syntax-top-level-await@^7.8.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz#dd6c0b357ac1bb142d98537450a319625d13d2a0"
   integrity sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==
@@ -970,6 +970,18 @@
     jest-util "^25.5.0"
     slash "^3.0.0"
 
+"@jest/console@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-26.6.2.tgz#4e04bc464014358b03ab4937805ee36a0aeb98f2"
+  integrity sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    jest-message-util "^26.6.2"
+    jest-util "^26.6.2"
+    slash "^3.0.0"
+
 "@jest/core@^25.5.4":
   version "25.5.4"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-25.5.4.tgz#3ef7412f7339210f003cdf36646bbca786efe7b4"
@@ -1004,6 +1016,40 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
+"@jest/core@^26.6.3":
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-26.6.3.tgz#7639fcb3833d748a4656ada54bde193051e45fad"
+  integrity sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
+  dependencies:
+    "@jest/console" "^26.6.2"
+    "@jest/reporters" "^26.6.2"
+    "@jest/test-result" "^26.6.2"
+    "@jest/transform" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    jest-changed-files "^26.6.2"
+    jest-config "^26.6.3"
+    jest-haste-map "^26.6.2"
+    jest-message-util "^26.6.2"
+    jest-regex-util "^26.0.0"
+    jest-resolve "^26.6.2"
+    jest-resolve-dependencies "^26.6.3"
+    jest-runner "^26.6.3"
+    jest-runtime "^26.6.3"
+    jest-snapshot "^26.6.2"
+    jest-util "^26.6.2"
+    jest-validate "^26.6.2"
+    jest-watcher "^26.6.2"
+    micromatch "^4.0.2"
+    p-each-series "^2.1.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
+
 "@jest/environment@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-25.5.0.tgz#aa33b0c21a716c65686638e7ef816c0e3a0c7b37"
@@ -1012,6 +1058,16 @@
     "@jest/fake-timers" "^25.5.0"
     "@jest/types" "^25.5.0"
     jest-mock "^25.5.0"
+
+"@jest/environment@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-26.6.2.tgz#ba364cc72e221e79cc8f0a99555bf5d7577cf92c"
+  integrity sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==
+  dependencies:
+    "@jest/fake-timers" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    jest-mock "^26.6.2"
 
 "@jest/fake-timers@^25.5.0":
   version "25.5.0"
@@ -1024,6 +1080,18 @@
     jest-util "^25.5.0"
     lolex "^5.0.0"
 
+"@jest/fake-timers@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-26.6.2.tgz#459c329bcf70cee4af4d7e3f3e67848123535aad"
+  integrity sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@types/node" "*"
+    jest-message-util "^26.6.2"
+    jest-mock "^26.6.2"
+    jest-util "^26.6.2"
+
 "@jest/globals@^25.5.2":
   version "25.5.2"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-25.5.2.tgz#5e45e9de8d228716af3257eeb3991cc2e162ca88"
@@ -1032,6 +1100,15 @@
     "@jest/environment" "^25.5.0"
     "@jest/types" "^25.5.0"
     expect "^25.5.0"
+
+"@jest/globals@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-26.6.2.tgz#5b613b78a1aa2655ae908eba638cc96a20df720a"
+  integrity sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==
+  dependencies:
+    "@jest/environment" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    expect "^26.6.2"
 
 "@jest/reporters@^25.5.1":
   version "25.5.1"
@@ -1065,10 +1142,51 @@
   optionalDependencies:
     node-notifier "^6.0.0"
 
+"@jest/reporters@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-26.6.2.tgz#1f518b99637a5f18307bd3ecf9275f6882a667f6"
+  integrity sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^26.6.2"
+    "@jest/test-result" "^26.6.2"
+    "@jest/transform" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    chalk "^4.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    graceful-fs "^4.2.4"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^4.0.3"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.2"
+    jest-haste-map "^26.6.2"
+    jest-resolve "^26.6.2"
+    jest-util "^26.6.2"
+    jest-worker "^26.6.2"
+    slash "^3.0.0"
+    source-map "^0.6.0"
+    string-length "^4.0.1"
+    terminal-link "^2.0.0"
+    v8-to-istanbul "^7.0.0"
+  optionalDependencies:
+    node-notifier "^8.0.0"
+
 "@jest/source-map@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-25.5.0.tgz#df5c20d6050aa292c2c6d3f0d2c7606af315bd1b"
   integrity sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==
+  dependencies:
+    callsites "^3.0.0"
+    graceful-fs "^4.2.4"
+    source-map "^0.6.0"
+
+"@jest/source-map@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-26.6.2.tgz#29af5e1e2e324cafccc936f218309f54ab69d535"
+  integrity sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==
   dependencies:
     callsites "^3.0.0"
     graceful-fs "^4.2.4"
@@ -1084,6 +1202,16 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
+"@jest/test-result@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-26.6.2.tgz#55da58b62df134576cc95476efa5f7949e3f5f18"
+  integrity sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==
+  dependencies:
+    "@jest/console" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
 "@jest/test-sequencer@^25.5.4":
   version "25.5.4"
   resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-25.5.4.tgz#9b4e685b36954c38d0f052e596d28161bdc8b737"
@@ -1094,6 +1222,17 @@
     jest-haste-map "^25.5.1"
     jest-runner "^25.5.4"
     jest-runtime "^25.5.4"
+
+"@jest/test-sequencer@^26.6.3":
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz#98e8a45100863886d074205e8ffdc5a7eb582b17"
+  integrity sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
+  dependencies:
+    "@jest/test-result" "^26.6.2"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^26.6.2"
+    jest-runner "^26.6.3"
+    jest-runtime "^26.6.3"
 
 "@jest/transform@^25.5.1":
   version "25.5.1"
@@ -1117,6 +1256,27 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
+"@jest/transform@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-26.6.2.tgz#5ac57c5fa1ad17b2aae83e73e45813894dcf2e4b"
+  integrity sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/types" "^26.6.2"
+    babel-plugin-istanbul "^6.0.0"
+    chalk "^4.0.0"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^26.6.2"
+    jest-regex-util "^26.0.0"
+    jest-util "^26.6.2"
+    micromatch "^4.0.2"
+    pirates "^4.0.1"
+    slash "^3.0.0"
+    source-map "^0.6.1"
+    write-file-atomic "^3.0.0"
+
 "@jest/types@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
@@ -1126,6 +1286,17 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
 
 "@next/env@10.0.5":
   version "10.0.5"
@@ -1261,6 +1432,13 @@
   dependencies:
     type-detect "4.0.8"
 
+"@sinonjs/fake-timers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
 "@size-limit/file@4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@size-limit/file/-/file-4.9.1.tgz#ce1798b5b4c87d6d4c0caf5ddd6ce5a7638b3307"
@@ -1300,7 +1478,7 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@types/babel__core@^7.1.7":
+"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
   integrity sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==
@@ -1326,7 +1504,7 @@
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.11.0.tgz#b9a1efa635201ba9bc850323a8793ee2d36c04a0"
   integrity sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==
@@ -1434,6 +1612,21 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
+"@types/jest@26.x", "@types/jest@^26.0.20":
+  version "26.0.20"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
+  integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/jest@^25.2.1":
   version "25.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.3.tgz#33d27e4c4716caae4eced355097a47ad363fdcaf"
@@ -1489,6 +1682,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
+"@types/prettier@^2.0.0":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.6.tgz#f4b1efa784e8db479cdb8b14403e2144b1e9ff03"
+  integrity sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==
+
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
@@ -1530,6 +1728,11 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/stack-utils@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
+  integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
 "@types/yargs-parser@*":
   version "20.2.0"
@@ -1741,7 +1944,7 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-abab@^2.0.0:
+abab@^2.0.0, abab@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
@@ -1768,6 +1971,14 @@ acorn-globals@^4.3.2:
   dependencies:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
+
+acorn-globals@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
+  integrity sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-walk "^7.1.1"
 
 acorn-jsx@^5.2.0:
   version "5.3.1"
@@ -2135,6 +2346,20 @@ babel-jest@^25.5.1:
     graceful-fs "^4.2.4"
     slash "^3.0.0"
 
+babel-jest@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
+  integrity sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==
+  dependencies:
+    "@jest/transform" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/babel__core" "^7.1.7"
+    babel-plugin-istanbul "^6.0.0"
+    babel-preset-jest "^26.6.2"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    slash "^3.0.0"
+
 babel-plugin-annotate-pure-calls@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.4.0.tgz#78aa00fd878c4fcde4d49f3da397fcf5defbcce8"
@@ -2170,6 +2395,16 @@ babel-plugin-jest-hoist@^25.5.0:
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
+    "@types/babel__traverse" "^7.0.6"
+
+babel-plugin-jest-hoist@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz#8185bd030348d254c6d7dd974355e6a28b21e62d"
+  integrity sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==
+  dependencies:
+    "@babel/template" "^7.3.3"
+    "@babel/types" "^7.3.3"
+    "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
 babel-plugin-macros@^2.6.1:
@@ -2228,6 +2463,24 @@ babel-preset-current-node-syntax@^0.1.2:
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
+babel-preset-current-node-syntax@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
+  integrity sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==
+  dependencies:
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-bigint" "^7.8.3"
+    "@babel/plugin-syntax-class-properties" "^7.8.3"
+    "@babel/plugin-syntax-import-meta" "^7.8.3"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.8.3"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-top-level-await" "^7.8.3"
+
 babel-preset-jest@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz#c1d7f191829487a907764c65307faa0e66590b49"
@@ -2235,6 +2488,14 @@ babel-preset-jest@^25.5.0:
   dependencies:
     babel-plugin-jest-hoist "^25.5.0"
     babel-preset-current-node-syntax "^0.1.2"
+
+babel-preset-jest@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz#747872b1171df032252426586881d62d31798fee"
+  integrity sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==
+  dependencies:
+    babel-plugin-jest-hoist "^26.6.2"
+    babel-preset-current-node-syntax "^1.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -2693,6 +2954,11 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+char-regex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
+  integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -2781,6 +3047,11 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+cjs-module-lexer@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f"
+  integrity sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -3378,7 +3649,7 @@ csso@^4.0.2:
   dependencies:
     css-tree "^1.1.2"
 
-cssom@^0.4.1:
+cssom@^0.4.1, cssom@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
   integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
@@ -3388,7 +3659,7 @@ cssom@~0.3.6:
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
   integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
 
-cssstyle@^2.0.0:
+cssstyle@^2.0.0, cssstyle@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
@@ -3434,6 +3705,15 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+data-urls@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
+  integrity sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==
+  dependencies:
+    abab "^2.0.3"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^8.0.0"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3452,6 +3732,11 @@ decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decimal.js@^10.2.0:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
+  integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -3576,6 +3861,11 @@ diff-sequences@^25.2.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
+diff-sequences@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
+  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -3661,6 +3951,13 @@ domexception@^1.0.1:
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
+
+domexception@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
+  integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
+  dependencies:
+    webidl-conversions "^5.0.0"
 
 domhandler@3.3.0, domhandler@^3.0.0, domhandler@^3.3.0:
   version "3.3.0"
@@ -3759,6 +4056,11 @@ elliptic@^6.5.3:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+emittery@^0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
+  integrity sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -3929,7 +4231,7 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-escodegen@^1.11.1:
+escodegen@^1.11.1, escodegen@^1.14.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
   integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
@@ -4231,7 +4533,7 @@ execa@^3.2.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@^4.0.3:
+execa@^4.0.0, execa@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
@@ -4280,6 +4582,18 @@ expect@^25.5.0:
     jest-matcher-utils "^25.5.0"
     jest-message-util "^25.5.0"
     jest-regex-util "^25.2.6"
+
+expect@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-26.6.2.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417"
+  integrity sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-styles "^4.0.0"
+    jest-get-type "^26.3.0"
+    jest-matcher-utils "^26.6.2"
+    jest-message-util "^26.6.2"
+    jest-regex-util "^26.0.0"
 
 express@^4.16.3, express@^4.17.1:
   version "4.17.1"
@@ -4992,6 +5306,13 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html-encoding-sniffer@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
+  integrity sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==
+  dependencies:
+    whatwg-encoding "^1.0.5"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -5457,6 +5778,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-potential-custom-element-name@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
+  integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
+
 is-reference@^1.1.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
@@ -5520,7 +5846,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is-wsl@^2.1.1:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -5559,7 +5885,7 @@ istanbul-lib-coverage@^3.0.0:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
   integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
 
-istanbul-lib-instrument@^4.0.0:
+istanbul-lib-instrument@^4.0.0, istanbul-lib-instrument@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz#873c6fff897450118222774696a3f28902d77c1d"
   integrity sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
@@ -5604,6 +5930,15 @@ jest-changed-files@^25.5.0:
     execa "^3.2.0"
     throat "^5.0.0"
 
+jest-changed-files@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.6.2.tgz#f6198479e1cc66f22f9ae1e22acaa0b429c042d0"
+  integrity sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    execa "^4.0.0"
+    throat "^5.0.0"
+
 jest-cli@^25.5.4:
   version "25.5.4"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-25.5.4.tgz#b9f1a84d1301a92c5c217684cb79840831db9f0d"
@@ -5623,6 +5958,25 @@ jest-cli@^25.5.4:
     prompts "^2.0.1"
     realpath-native "^2.0.0"
     yargs "^15.3.1"
+
+jest-cli@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-26.6.3.tgz#43117cfef24bc4cd691a174a8796a532e135e92a"
+  integrity sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
+  dependencies:
+    "@jest/core" "^26.6.3"
+    "@jest/test-result" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    chalk "^4.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    import-local "^3.0.2"
+    is-ci "^2.0.0"
+    jest-config "^26.6.3"
+    jest-util "^26.6.2"
+    jest-validate "^26.6.2"
+    prompts "^2.0.1"
+    yargs "^15.4.1"
 
 jest-config@^25.5.4:
   version "25.5.4"
@@ -5649,6 +6003,30 @@ jest-config@^25.5.4:
     pretty-format "^25.5.0"
     realpath-native "^2.0.0"
 
+jest-config@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-26.6.3.tgz#64f41444eef9eb03dc51d5c53b75c8c71f645349"
+  integrity sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^26.6.3"
+    "@jest/types" "^26.6.2"
+    babel-jest "^26.6.3"
+    chalk "^4.0.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.1"
+    graceful-fs "^4.2.4"
+    jest-environment-jsdom "^26.6.2"
+    jest-environment-node "^26.6.2"
+    jest-get-type "^26.3.0"
+    jest-jasmine2 "^26.6.3"
+    jest-regex-util "^26.0.0"
+    jest-resolve "^26.6.2"
+    jest-util "^26.6.2"
+    jest-validate "^26.6.2"
+    micromatch "^4.0.2"
+    pretty-format "^26.6.2"
+
 jest-diff@^25.2.1, jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
@@ -5659,10 +6037,27 @@ jest-diff@^25.2.1, jest-diff@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
+jest-diff@^26.0.0, jest-diff@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
+  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
+
 jest-docblock@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.3.0.tgz#8b777a27e3477cd77a168c05290c471a575623ef"
   integrity sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==
+  dependencies:
+    detect-newline "^3.0.0"
+
+jest-docblock@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
+  integrity sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==
   dependencies:
     detect-newline "^3.0.0"
 
@@ -5677,6 +6072,17 @@ jest-each@^25.5.0:
     jest-util "^25.5.0"
     pretty-format "^25.5.0"
 
+jest-each@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-26.6.2.tgz#02526438a77a67401c8a6382dfe5999952c167cb"
+  integrity sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    chalk "^4.0.0"
+    jest-get-type "^26.3.0"
+    jest-util "^26.6.2"
+    pretty-format "^26.6.2"
+
 jest-environment-jsdom@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz#dcbe4da2ea997707997040ecf6e2560aec4e9834"
@@ -5688,6 +6094,19 @@ jest-environment-jsdom@^25.5.0:
     jest-mock "^25.5.0"
     jest-util "^25.5.0"
     jsdom "^15.2.1"
+
+jest-environment-jsdom@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz#78d09fe9cf019a357009b9b7e1f101d23bd1da3e"
+  integrity sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
+  dependencies:
+    "@jest/environment" "^26.6.2"
+    "@jest/fake-timers" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    jest-mock "^26.6.2"
+    jest-util "^26.6.2"
+    jsdom "^16.4.0"
 
 jest-environment-node@^25.5.0:
   version "25.5.0"
@@ -5701,10 +6120,27 @@ jest-environment-node@^25.5.0:
     jest-util "^25.5.0"
     semver "^6.3.0"
 
+jest-environment-node@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-26.6.2.tgz#824e4c7fb4944646356f11ac75b229b0035f2b0c"
+  integrity sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==
+  dependencies:
+    "@jest/environment" "^26.6.2"
+    "@jest/fake-timers" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    jest-mock "^26.6.2"
+    jest-util "^26.6.2"
+
 jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
   integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
+
+jest-get-type@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
+  integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
 jest-haste-map@^25.5.1:
   version "25.5.1"
@@ -5723,6 +6159,27 @@ jest-haste-map@^25.5.1:
     sane "^4.0.3"
     walker "^1.0.7"
     which "^2.0.2"
+  optionalDependencies:
+    fsevents "^2.1.2"
+
+jest-haste-map@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-26.6.2.tgz#dd7e60fe7dc0e9f911a23d79c5ff7fb5c2cafeaa"
+  integrity sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    "@types/graceful-fs" "^4.1.2"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-regex-util "^26.0.0"
+    jest-serializer "^26.6.2"
+    jest-util "^26.6.2"
+    jest-worker "^26.6.2"
+    micromatch "^4.0.2"
+    sane "^4.0.3"
+    walker "^1.0.7"
   optionalDependencies:
     fsevents "^2.1.2"
 
@@ -5749,6 +6206,30 @@ jest-jasmine2@^25.5.4:
     pretty-format "^25.5.0"
     throat "^5.0.0"
 
+jest-jasmine2@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz#adc3cf915deacb5212c93b9f3547cd12958f2edd"
+  integrity sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^26.6.2"
+    "@jest/source-map" "^26.6.2"
+    "@jest/test-result" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    expect "^26.6.2"
+    is-generator-fn "^2.0.0"
+    jest-each "^26.6.2"
+    jest-matcher-utils "^26.6.2"
+    jest-message-util "^26.6.2"
+    jest-runtime "^26.6.3"
+    jest-snapshot "^26.6.2"
+    jest-util "^26.6.2"
+    pretty-format "^26.6.2"
+    throat "^5.0.0"
+
 jest-leak-detector@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz#2291c6294b0ce404241bb56fe60e2d0c3e34f0bb"
@@ -5756,6 +6237,14 @@ jest-leak-detector@^25.5.0:
   dependencies:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
+
+jest-leak-detector@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz#7717cf118b92238f2eba65054c8a0c9c653a91af"
+  integrity sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==
+  dependencies:
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
 
 jest-matcher-utils@^25.5.0:
   version "25.5.0"
@@ -5766,6 +6255,16 @@ jest-matcher-utils@^25.5.0:
     jest-diff "^25.5.0"
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
+
+jest-matcher-utils@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
+  integrity sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
 
 jest-message-util@^25.5.0:
   version "25.5.0"
@@ -5781,6 +6280,21 @@ jest-message-util@^25.5.0:
     slash "^3.0.0"
     stack-utils "^1.0.1"
 
+jest-message-util@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-26.6.2.tgz#58173744ad6fc0506b5d21150b9be56ef001ca07"
+  integrity sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/types" "^26.6.2"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.2"
+    pretty-format "^26.6.2"
+    slash "^3.0.0"
+    stack-utils "^2.0.2"
+
 jest-mock@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-25.5.0.tgz#a91a54dabd14e37ecd61665d6b6e06360a55387a"
@@ -5788,7 +6302,15 @@ jest-mock@^25.5.0:
   dependencies:
     "@jest/types" "^25.5.0"
 
-jest-pnp-resolver@^1.2.1:
+jest-mock@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.6.2.tgz#d6cb712b041ed47fe0d9b6fc3474bc6543feb302"
+  integrity sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+
+jest-pnp-resolver@^1.2.1, jest-pnp-resolver@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
   integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
@@ -5798,6 +6320,11 @@ jest-regex-util@^25.2.1, jest-regex-util@^25.2.6:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-25.2.6.tgz#d847d38ba15d2118d3b06390056028d0f2fd3964"
   integrity sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==
 
+jest-regex-util@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
+  integrity sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
+
 jest-resolve-dependencies@^25.5.4:
   version "25.5.4"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.4.tgz#85501f53957c8e3be446e863a74777b5a17397a7"
@@ -5806,6 +6333,15 @@ jest-resolve-dependencies@^25.5.4:
     "@jest/types" "^25.5.0"
     jest-regex-util "^25.2.6"
     jest-snapshot "^25.5.1"
+
+jest-resolve-dependencies@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz#6680859ee5d22ee5dcd961fe4871f59f4c784fb6"
+  integrity sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    jest-regex-util "^26.0.0"
+    jest-snapshot "^26.6.2"
 
 jest-resolve@^25.5.1:
   version "25.5.1"
@@ -5820,6 +6356,20 @@ jest-resolve@^25.5.1:
     read-pkg-up "^7.0.1"
     realpath-native "^2.0.0"
     resolve "^1.17.0"
+    slash "^3.0.0"
+
+jest-resolve@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-26.6.2.tgz#a3ab1517217f469b504f1b56603c5bb541fbb507"
+  integrity sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    jest-pnp-resolver "^1.2.2"
+    jest-util "^26.6.2"
+    read-pkg-up "^7.0.1"
+    resolve "^1.18.1"
     slash "^3.0.0"
 
 jest-runner@^25.5.4:
@@ -5844,6 +6394,32 @@ jest-runner@^25.5.4:
     jest-runtime "^25.5.4"
     jest-util "^25.5.0"
     jest-worker "^25.5.0"
+    source-map-support "^0.5.6"
+    throat "^5.0.0"
+
+jest-runner@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-26.6.3.tgz#2d1fed3d46e10f233fd1dbd3bfaa3fe8924be159"
+  integrity sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
+  dependencies:
+    "@jest/console" "^26.6.2"
+    "@jest/environment" "^26.6.2"
+    "@jest/test-result" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    emittery "^0.7.1"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    jest-config "^26.6.3"
+    jest-docblock "^26.0.0"
+    jest-haste-map "^26.6.2"
+    jest-leak-detector "^26.6.2"
+    jest-message-util "^26.6.2"
+    jest-resolve "^26.6.2"
+    jest-runtime "^26.6.3"
+    jest-util "^26.6.2"
+    jest-worker "^26.6.2"
     source-map-support "^0.5.6"
     throat "^5.0.0"
 
@@ -5879,11 +6455,52 @@ jest-runtime@^25.5.4:
     strip-bom "^4.0.0"
     yargs "^15.3.1"
 
+jest-runtime@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-26.6.3.tgz#4f64efbcfac398331b74b4b3c82d27d401b8fa2b"
+  integrity sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
+  dependencies:
+    "@jest/console" "^26.6.2"
+    "@jest/environment" "^26.6.2"
+    "@jest/fake-timers" "^26.6.2"
+    "@jest/globals" "^26.6.2"
+    "@jest/source-map" "^26.6.2"
+    "@jest/test-result" "^26.6.2"
+    "@jest/transform" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+    cjs-module-lexer "^0.6.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.4"
+    jest-config "^26.6.3"
+    jest-haste-map "^26.6.2"
+    jest-message-util "^26.6.2"
+    jest-mock "^26.6.2"
+    jest-regex-util "^26.0.0"
+    jest-resolve "^26.6.2"
+    jest-snapshot "^26.6.2"
+    jest-util "^26.6.2"
+    jest-validate "^26.6.2"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+    yargs "^15.4.1"
+
 jest-serializer@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-25.5.0.tgz#a993f484e769b4ed54e70e0efdb74007f503072b"
   integrity sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==
   dependencies:
+    graceful-fs "^4.2.4"
+
+jest-serializer@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-26.6.2.tgz#d139aafd46957d3a448f3a6cdabe2919ba0742d1"
+  integrity sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==
+  dependencies:
+    "@types/node" "*"
     graceful-fs "^4.2.4"
 
 jest-snapshot@^25.5.1:
@@ -5907,6 +6524,28 @@ jest-snapshot@^25.5.1:
     pretty-format "^25.5.0"
     semver "^6.3.0"
 
+jest-snapshot@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-26.6.2.tgz#f3b0af1acb223316850bd14e1beea9837fb39c84"
+  integrity sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==
+  dependencies:
+    "@babel/types" "^7.0.0"
+    "@jest/types" "^26.6.2"
+    "@types/babel__traverse" "^7.0.4"
+    "@types/prettier" "^2.0.0"
+    chalk "^4.0.0"
+    expect "^26.6.2"
+    graceful-fs "^4.2.4"
+    jest-diff "^26.6.2"
+    jest-get-type "^26.3.0"
+    jest-haste-map "^26.6.2"
+    jest-matcher-utils "^26.6.2"
+    jest-message-util "^26.6.2"
+    jest-resolve "^26.6.2"
+    natural-compare "^1.4.0"
+    pretty-format "^26.6.2"
+    semver "^7.3.2"
+
 jest-util@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-25.5.0.tgz#31c63b5d6e901274d264a4fec849230aa3fa35b0"
@@ -5917,6 +6556,18 @@ jest-util@^25.5.0:
     graceful-fs "^4.2.4"
     is-ci "^2.0.0"
     make-dir "^3.0.0"
+
+jest-util@^26.1.0, jest-util@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
+  integrity sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^2.0.0"
+    micromatch "^4.0.2"
 
 jest-validate@^25.5.0:
   version "25.5.0"
@@ -5929,6 +6580,18 @@ jest-validate@^25.5.0:
     jest-get-type "^25.2.6"
     leven "^3.1.0"
     pretty-format "^25.5.0"
+
+jest-validate@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.2.tgz#23d380971587150467342911c3d7b4ac57ab20ec"
+  integrity sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    camelcase "^6.0.0"
+    chalk "^4.0.0"
+    jest-get-type "^26.3.0"
+    leven "^3.1.0"
+    pretty-format "^26.6.2"
 
 jest-watch-typeahead@^0.5.0:
   version "0.5.0"
@@ -5955,6 +6618,19 @@ jest-watcher@^25.2.4, jest-watcher@^25.5.0:
     jest-util "^25.5.0"
     string-length "^3.1.0"
 
+jest-watcher@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-26.6.2.tgz#a5b683b8f9d68dbcb1d7dae32172d2cca0592975"
+  integrity sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==
+  dependencies:
+    "@jest/test-result" "^26.6.2"
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    jest-util "^26.6.2"
+    string-length "^4.0.1"
+
 jest-worker@24.9.0, jest-worker@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
@@ -5971,6 +6647,15 @@ jest-worker@^25.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jest-worker@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
+  integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
+
 jest@^25.3.0:
   version "25.5.4"
   resolved "https://registry.yarnpkg.com/jest/-/jest-25.5.4.tgz#f21107b6489cfe32b076ce2adcadee3587acb9db"
@@ -5979,6 +6664,15 @@ jest@^25.3.0:
     "@jest/core" "^25.5.4"
     import-local "^3.0.2"
     jest-cli "^25.5.4"
+
+jest@^26.6.3:
+  version "26.6.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.3.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
+  integrity sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
+  dependencies:
+    "@jest/core" "^26.6.3"
+    import-local "^3.0.2"
+    jest-cli "^26.6.3"
 
 jpjs@^1.2.1:
   version "1.2.1"
@@ -6033,6 +6727,38 @@ jsdom@^15.2.1:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^7.0.0"
     ws "^7.0.0"
+    xml-name-validator "^3.0.0"
+
+jsdom@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.4.0.tgz#36005bde2d136f73eee1a830c6d45e55408edddb"
+  integrity sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==
+  dependencies:
+    abab "^2.0.3"
+    acorn "^7.1.1"
+    acorn-globals "^6.0.0"
+    cssom "^0.4.4"
+    cssstyle "^2.2.0"
+    data-urls "^2.0.0"
+    decimal.js "^10.2.0"
+    domexception "^2.0.1"
+    escodegen "^1.14.1"
+    html-encoding-sniffer "^2.0.1"
+    is-potential-custom-element-name "^1.0.0"
+    nwsapi "^2.2.0"
+    parse5 "5.1.1"
+    request "^2.88.2"
+    request-promise-native "^1.0.8"
+    saxes "^5.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^3.0.1"
+    w3c-hr-time "^1.0.2"
+    w3c-xmlserializer "^2.0.0"
+    webidl-conversions "^6.1.0"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^8.0.0"
+    ws "^7.2.3"
     xml-name-validator "^3.0.0"
 
 jsesc@^2.5.1:
@@ -6324,7 +7050,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5:
+lodash@4.x, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -6638,7 +7364,7 @@ mkdirp@0.x, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^1.0.4:
+mkdirp@1.x, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -6879,6 +7605,18 @@ node-notifier@^6.0.0:
     semver "^6.3.0"
     shellwords "^0.1.1"
     which "^1.3.1"
+
+node-notifier@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
+  integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
+  dependencies:
+    growly "^1.3.0"
+    is-wsl "^2.2.0"
+    semver "^7.3.2"
+    shellwords "^0.1.1"
+    uuid "^8.3.0"
+    which "^2.0.2"
 
 node-releases@^1.1.65, node-releases@^1.1.69:
   version "1.1.70"
@@ -7296,6 +8034,11 @@ parse5@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
   integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+
+parse5@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
 parseurl@~1.3.3:
   version "1.3.3"
@@ -7910,6 +8653,16 @@ pretty-format@^25.2.1, pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^26.0.0, pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -8112,6 +8865,11 @@ react-is@16.13.1, react-is@^16.12.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
 react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
@@ -8304,7 +9062,7 @@ request-promise-core@1.1.4:
   dependencies:
     lodash "^4.17.19"
 
-request-promise-native@^1.0.7:
+request-promise-native@^1.0.7, request-promise-native@^1.0.8:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.9.tgz#e407120526a5efdc9a39b28a5679bf47b9d9dc28"
   integrity sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
@@ -8313,7 +9071,7 @@ request-promise-native@^1.0.7:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.88.0:
+request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -8644,6 +9402,13 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
+saxes@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
+  integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
+  dependencies:
+    xmlchars "^2.2.0"
+
 schema-utils@2.7.1, schema-utils@^2.6.6, schema-utils@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
@@ -8696,7 +9461,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.3.4, semver@^7.1.1, semver@^7.3.2:
+semver@7.3.4, semver@7.x, semver@^7.1.1, semver@^7.3.2:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
@@ -9082,6 +9847,13 @@ stack-utils@^1.0.1:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stack-utils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
+  integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
 stacktrace-parser@0.1.10:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
@@ -9159,6 +9931,14 @@ string-length@^3.1.0:
   dependencies:
     astral-regex "^1.0.0"
     strip-ansi "^5.2.0"
+
+string-length@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.1.tgz#4a973bf31ef77c4edbceadd6af2611996985f8a1"
+  integrity sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==
+  dependencies:
+    char-regex "^1.0.2"
+    strip-ansi "^6.0.0"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -9393,7 +10173,7 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-tree@^3.2.2:
+symbol-tree@^3.2.2, symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
@@ -9629,6 +10409,13 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tr46@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.0.2.tgz#03273586def1595ae08fedb38d7733cee91d2479"
+  integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
+  dependencies:
+    punycode "^2.1.1"
+
 traverse@0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
@@ -9654,6 +10441,23 @@ ts-jest@^25.3.1:
     mkdirp "0.x"
     semver "6.x"
     yargs-parser "18.x"
+
+ts-jest@^26.5.0:
+  version "26.5.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.0.tgz#3e3417d91bc40178a6716d7dacc5b0505835aa21"
+  integrity sha512-Ya4IQgvIFNa2Mgq52KaO8yBw2W8tWp61Ecl66VjF0f5JaV8u50nGoptHVILOPGoI7SDnShmEqnYQEmyHdQ+56g==
+  dependencies:
+    "@types/jest" "26.x"
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^26.1.0"
+    json5 "2.x"
+    lodash "4.x"
+    make-error "1.x"
+    mkdirp "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
 
 ts-pnp@^1.1.6:
   version "1.2.0"
@@ -10009,6 +10813,11 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache@^2.0.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
@@ -10018,6 +10827,15 @@ v8-to-istanbul@^4.1.3:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz#b97936f21c0e2d9996d4985e5c5156e9d4e49cd6"
   integrity sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^1.6.0"
+    source-map "^0.7.3"
+
+v8-to-istanbul@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz#5b95cef45c0f83217ec79f8fc7ee1c8b486aee07"
+  integrity sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
@@ -10055,7 +10873,7 @@ vm-browserify@1.1.2, vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-w3c-hr-time@^1.0.1:
+w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
   integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
@@ -10069,6 +10887,13 @@ w3c-xmlserializer@^1.1.2:
   dependencies:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
+    xml-name-validator "^3.0.0"
+
+w3c-xmlserializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz#3e7104a05b75146cc60f564380b7f683acf1020a"
+  integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
+  dependencies:
     xml-name-validator "^3.0.0"
 
 walker@^1.0.7, walker@~1.0.5:
@@ -10115,6 +10940,16 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+webidl-conversions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
+
+webidl-conversions@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
+  integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
 webpack-bundle-analyzer@^3.9.0:
   version "3.9.0"
@@ -10222,6 +11057,15 @@ whatwg-url@^7.0.0:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
+whatwg-url@^8.0.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.4.0.tgz#50fb9615b05469591d2b2bd6dfaed2942ed72837"
+  integrity sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^2.0.2"
+    webidl-conversions "^6.1.0"
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
@@ -10311,7 +11155,7 @@ ws@^6.0.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.0.0:
+ws@^7.0.0, ws@^7.2.3:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
   integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
@@ -10321,7 +11165,7 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xmlchars@^2.1.1:
+xmlchars@^2.1.1, xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
@@ -10359,7 +11203,12 @@ yargs-parser@18.x, yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs@^15.3.1:
+yargs-parser@20.x:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+
+yargs@^15.3.1, yargs@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
…llow usage of a sub-api directly, make all options configurable in a consistent manner

@colinclerk @SokratisVidros Please read the updated README & examples for a better overview of the new proposed usage.

The intention, based on Colin's proposal, was to have 2 potential variants available for import:

* `@clerk/clerk-sdk-node` - default export is a singleton instance, good for 95% of cases
* `@clerk/clerk-sdk-node/instance` - default export is the constructor, doesn't instantiate a singleton instance

Note: all other deps are exported by both modules so that you only need to import from one source.

Currently the second "manifest" is hindered by the apparent [lack of support for multiple entries in tsdx](https://github.com/formium/tsdx/pull/367). We'll have to figure out a workaround.

For the time being I'm also exporting the constructor in the first package, so that the developer can instantiate themselves using that.

P.S. The case or `Clerk.default` is a non-issue after all, caused by the import of an ESM module in a CJS context.
See usage with CJS in the README for more.