### PR TITLE
Allow user update to modify user custom attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.log
 .DS_Store
+.idea
 node_modules
 dist
 .env

--- a/src/apis/UserApi.ts
+++ b/src/apis/UserApi.ts
@@ -8,6 +8,8 @@ interface UserParams {
   password?: string;
   primaryEmailAddressID?: string;
   primaryPhoneNumberID?: string;
+  publicMetadata?: object;
+  privateMetadata?: object;
 }
 
 export class UserApi extends AbstractApi {

--- a/src/resources/User.ts
+++ b/src/resources/User.ts
@@ -12,7 +12,7 @@ import { GoogleAccount } from './GoogleAccount';
 import { PhoneNumber } from './PhoneNumber';
 
 export class User implements UserResource {
-  id: string
+  id: string;
   username: string | null;
   firstName: string | null;
   lastName: string | null;
@@ -26,7 +26,7 @@ export class User implements UserResource {
   emailAddresses: EmailAddressResource[];
   phoneNumbers: PhoneNumberResource[];
   externalAccounts: GoogleAccountResource[];
-  metadata: object;
+  publicMetadata: object;
   privateMetadata: object;
   createdAt: number;
   updatedAt: number;
@@ -46,7 +46,7 @@ export class User implements UserResource {
     this.emailAddresses = data.email_addresses.map((x) => new EmailAddress(x));
     this.phoneNumbers = data.phone_numbers.map((x) => new PhoneNumber(x));
     this.externalAccounts = data.external_accounts.map((x: GoogleAccountJSON) => new GoogleAccount(x));
-    this.metadata = data.metadata;
+    this.publicMetadata = data.public_metadata;
     this.privateMetadata = data.private_metadata;
     this.createdAt = data.created_at;
     this.updatedAt = data.updated_at;

--- a/src/types/resources.d.ts
+++ b/src/types/resources.d.ts
@@ -201,7 +201,7 @@ export interface UserJSON extends ClerkResourceJSON {
   email_addresses: EmailAddressJSON[];
   phone_numbers: PhoneNumberJSON[];
   external_accounts: GoogleAccountJSON[];
-  metadata: object;
+  public_metadata: object;
   private_metadata: object;
   created_at: number;
   updated_at: number;
@@ -221,7 +221,7 @@ export interface UserResource extends ClerkResource {
   emailAddresses: EmailAddressResource[];
   phoneNumbers: PhoneNumberResource[];
   externalAccounts: GoogleAccountResource[];
-  metadata: object;
+  publicMetadata: object;
   privateMetadata: object;
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
When updating a user, you can optionally define public and private metadata.

This metadata are JSON objects of any form and will be stored and returned along with the user itself.