### PR TITLE
Object type on metadata prevents getting values

### DIFF
--- a/src/resources/Props.ts
+++ b/src/resources/Props.ts
@@ -117,8 +117,8 @@ export interface UserProps extends ClerkProps {
   // emailAddresses: EmailAddressProps[];
   // phoneNumbers: PhoneNumberProps[];
   // externalAccounts: GoogleAccountProps[];
-  publicMetadata: object;
-  privateMetadata: object;
+  publicMetadata: {[key: string]: string};
+  privateMetadata: {[key: string]: string};
   createdAt: Nullable<number>;
   updatedAt: Nullable<number>;
 }


### PR DESCRIPTION
When `xMetadata` is an `object` type, it prevents accessing properties in a type-safe way:

![image](https://user-images.githubusercontent.com/7143571/108927180-cd8aa500-760d-11eb-943a-91371fd40789.png)

`eslint` recommends using `Record<string, unknown>` instead, based on [this issue](https://github.com/microsoft/TypeScript/issues/21732).

![image](https://user-images.githubusercontent.com/7143571/108927278-f874f900-760d-11eb-871a-708706e0101a.png)

Here, I set it to `{[key: string]: string}` to be a little more restrictive and closer to how I've seen other `metadata`s used (i.e. Stripe's). Either works for my use case, curious to see what you guys think.
