### PR TITLE
Using the new server API endpoint /sessions/verify to simplify the verification process

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ the [official Clerk server API documentation](https://docs.clerk.dev/server-api/
         - [getSession(sessionId)](#getsessionsessionid)
         - [revokeSession(sessionId)](#revokesessionsessionid)
         - [verifySession(sessionId, sessionToken)](#verifysessionsessionid-sessiontoken)
+        - [verify(sessionToken)](#verifysessionsessiontoken)
     - [User operations](#user-operations)
         - [getUserList()](#getuserlist)
         - [getUser(userId)](#getuseruserid)
@@ -305,6 +306,15 @@ Verifies whether a session with a given id corresponds to the provided session t
 const sessionId = "my-session-id";
 const sessionToken = "my-session-token";
 let session = await clerk.sessions.verifySession(sessionId, sessionToken);
+```
+
+#### verify(sessionToken)
+
+Retrieves the client's last active session and verifies it corresponds to the provided session token:
+
+```
+const sessionToken = "my-session-token";
+let session = await clerk.sessions.verify(sessionToken);
 ```
 
 ### User operations

--- a/src/Clerk.ts
+++ b/src/Clerk.ts
@@ -156,16 +156,18 @@ export default class Clerk {
 
         Logger.debug(`sessionId from query: ${sessionId}`);
 
-        if (!sessionId) {
-          client = await this.clients.verifyClient(sessionToken);
-          sessionId = client.lastActiveSessionId;
-          Logger.debug(`lastActiveSessionId from client: ${sessionId}`);
-        }
+        let session: (Session | null) = null;
 
-        const session = await this.sessions.verifySession(
-          sessionId,
-          sessionToken
-        );
+        if (!sessionId) {
+          Logger.debug('retrieving last active session for client');
+          session = await this.sessions.verify(sessionToken);
+        } else {
+          Logger.debug(`retrieving session ${sessionId}`);
+          session = await this.sessions.verifySession(
+              sessionId,
+              sessionToken
+          );
+        }
 
         // Set Clerk session on request
         // TBD Set on state / locals instead?

--- a/src/__tests__/apis/SessionApi.test.ts
+++ b/src/__tests__/apis/SessionApi.test.ts
@@ -87,3 +87,29 @@ test('verifySession() returns a session if verified', async () => {
 
   expect(session).toEqual(expected);
 });
+
+test('verify() returns a session if verified', async () => {
+  const expected = new Session({
+    id: 'sess_oops',
+    clientId: 'client_isalwayswrong',
+    userId: 'user_player1',
+    status: 'active',
+    lastActiveAt: 1613593533,
+    expireAt: 1614198333,
+    abandonAt: 1616185533,
+  });
+
+  const sessionToken = 'random_jwt_token';
+
+  const encodedBody = new URLSearchParams({ token: sessionToken }).toString();
+
+  nock('https://api.clerk.dev')
+      .post(`/v1/sessions/verify`, encodedBody)
+      .replyWithFile(200, __dirname + '/responses/getSession.json', {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      });
+
+  const session = await sessions.verify(sessionToken);
+
+  expect(session).toEqual(expected);
+});

--- a/src/apis/SessionApi.ts
+++ b/src/apis/SessionApi.ts
@@ -41,4 +41,12 @@ export class SessionApi extends AbstractApi {
       bodyParams: { token },
     });
   }
+
+  public async verify(token: string): Promise<Session> {
+    return this._restClient.makeRequest({
+      method: 'post',
+      path: `/sessions/verify`,
+      bodyParams: { token },
+    });
+  }
 }


### PR DESCRIPTION
Modified the logic for session verification to use the new server API endpoint:
```
POST /v1/sessions/verify
```

This endpoint will verify the given session token and will return corresponding client's latest active session.