### PR TITLE
When verifying session token without session id, use verified client's sessions

### DIFF
--- a/src/__tests__/apis/ClientApi.test.ts
+++ b/src/__tests__/apis/ClientApi.test.ts
@@ -16,6 +16,15 @@ test('getClientList() returns a list of clients', async () => {
   const expected1 = new Client({
     id: 'client_isalwaysright',
     sessionIds: ['sess_swag'],
+    sessions: [{
+      id: 'sess_swag',
+      clientId: 'client_isalwaysright',
+      userId: 'user_player1',
+      status: 'active',
+      lastActiveAt: 1610706634,
+      expireAt: 1630846634,
+      abandonAt: 1630846634
+    }],
     signInAttemptId: null,
     signUpAttemptId: null,
     lastActiveSessionId: 'sess_swag',
@@ -26,6 +35,15 @@ test('getClientList() returns a list of clients', async () => {
   const expected2 = new Client({
     id: 'client_keysersoze',
     sessionIds: ['sess_mood'],
+    sessions: [{
+      id: 'sess_mood',
+      clientId: 'client_keysersoze',
+      userId: 'user_player2',
+      status: 'active',
+      lastActiveAt: 1610706634,
+      expireAt: 1630846634,
+      abandonAt: 1630846634
+    }],
     signInAttemptId: 'sia_qwerty',
     signUpAttemptId: null,
     lastActiveSessionId: null,
@@ -41,6 +59,15 @@ test('getClient() returns a single client', async () => {
   const expected = new Client({
     id: 'client_server',
     sessionIds: ['sess_onthebeach'],
+    sessions: [{
+      id: 'sess_onthebeach',
+      clientId: 'client_server',
+      userId: 'user_player1',
+      status: 'active',
+      lastActiveAt: 1610706634,
+      expireAt: 1630846634,
+      abandonAt: 1630846634,
+    }],
     signInAttemptId: 'sia_cheepthrills',
     signUpAttemptId: null,
     lastActiveSessionId: null,
@@ -63,6 +90,15 @@ test('verifyClient() returns a client if verified', async () => {
   const expected = new Client({
     id: 'client_server',
     sessionIds: ['sess_onthebeach'],
+    sessions: [{
+      id: 'sess_onthebeach',
+      clientId: 'client_server',
+      userId: 'user_player1',
+      status: 'active',
+      lastActiveAt: 1610706634,
+      expireAt: 1630846634,
+      abandonAt: 1630846634,
+    }],
     signInAttemptId: 'sia_cheepthrills',
     signUpAttemptId: null,
     lastActiveSessionId: null,

--- a/src/__tests__/apis/responses/getClient.json
+++ b/src/__tests__/apis/responses/getClient.json
@@ -2,6 +2,15 @@
     "object": "client",
     "id": "client_server",
     "session_ids": ["sess_onthebeach"],
+    "sessions": [{
+        "id": "sess_onthebeach",
+        "clientId": "client_server",
+        "userId": "user_player1",
+        "status": "active",
+        "lastActiveAt": 1610706634,
+        "expireAt": 1630846634,
+        "abandonAt": 1630846634
+    }],
     "sign_in_attempt_id": "sia_cheepthrills",
     "sign_up_attempt_id": null,
     "last_active_session_id": null,

--- a/src/__tests__/apis/responses/getClientList.json
+++ b/src/__tests__/apis/responses/getClientList.json
@@ -3,6 +3,15 @@
         "object": "client",
         "id": "client_isalwaysright",
         "session_ids": ["sess_swag"],
+        "sessions": [{
+            "id": "sess_swag",
+            "clientId": "client_isalwaysright",
+            "userId": "user_player1",
+            "status": "active",
+            "lastActiveAt": 1610706634,
+            "expireAt": 1630846634,
+            "abandonAt": 1630846634
+        }],
         "sign_in_attempt_id": null,
         "sign_up_attempt_id": null,
         "last_active_session_id": "sess_swag",
@@ -13,6 +22,15 @@
         "object": "client",
         "id": "client_keysersoze",
         "session_ids": ["sess_mood"],
+        "sessions": [{
+            "id": "sess_mood",
+            "clientId": "client_keysersoze",
+            "userId": "user_player2",
+            "status": "active",
+            "lastActiveAt": 1610706634,
+            "expireAt": 1630846634,
+            "abandonAt": 1630846634
+        }],
         "sign_in_attempt_id": "sia_qwerty",
         "sign_up_attempt_id": null,
         "last_active_session_id": null,

--- a/src/__tests__/resources/Client.test.ts
+++ b/src/__tests__/resources/Client.test.ts
@@ -1,0 +1,6 @@
+import { Client } from '../../resources/Client';
+
+test('client defaults', function() {
+    const client = new Client();
+    expect(client.sessions).toEqual([]);
+});

--- a/src/resources/Client.ts
+++ b/src/resources/Client.ts
@@ -1,26 +1,46 @@
 import camelcaseKeys from 'camelcase-keys';
 import filterKeys from '../utils/Filter';
+import associationDefaults from "../utils/Associations";
 
+import { Association } from "./Enums";
 import type { ClientJSON } from './JSON';
 import type { ClientProps } from './Props';
 
-interface ClientPayload extends ClientProps {};
+import { Session } from "./Session";
+
+interface ClientAssociations {
+  sessions: Session[];
+}
+
+interface ClientPayload extends ClientProps, ClientAssociations {};
 
 export interface Client extends ClientPayload {};
 
 export class Client {
   static attributes = ['id', 'sessionIds', 'signUpAttemptId', 'signInAttemptId',
-    'lastActiveSessionId', 'lastActiveSessionId', 'createdAt', 'updatedAt'];
+    'lastActiveSessionId', 'createdAt', 'updatedAt'];
 
-  static defaults = {};
+  static associations = {
+    sessions: Association.HasMany
+  };
+
+  static defaults = {
+    ...associationDefaults(Client.associations)
+  };
 
   constructor(data: Partial<ClientPayload> = {}) {
     Object.assign(this, Client.defaults, data);
   }
 
   static fromJSON(data: ClientJSON): Client {
+    const obj: Record<string, any> = {};
+
     const camelcased = camelcaseKeys(data);
     const filtered = filterKeys(camelcased, Client.attributes);
-    return new Client(filtered as ClientPayload);
+    Object.assign(obj, filtered);
+
+    obj.sessions = (data.sessions || []).map((x) => Session.fromJSON(x));
+
+    return new Client(obj as ClientPayload);
   }
 }

--- a/src/resources/JSON.ts
+++ b/src/resources/JSON.ts
@@ -29,6 +29,7 @@ export interface ClerkResourceJSON {
 export interface ClientJSON extends ClerkResourceJSON {
   object: ObjectType.Client;
   session_ids: string[];
+  sessions: SessionJSON[];
   sign_in_attempt_id: string | null;
   sign_up_attempt_id: string | null;
   last_active_session_id: string | null;

--- a/src/resources/Props.ts
+++ b/src/resources/Props.ts
@@ -20,6 +20,7 @@ export interface ClerkProps {
 
 export interface ClientProps extends ClerkProps {
   sessionIds: string[];
+  // sessions: SessionProps[];
   signInAttemptId: Nullable<string>;
   signUpAttemptId: Nullable<string>;
   lastActiveSessionId: Nullable<string>;


### PR DESCRIPTION
The client verification endpoint of the backend API now returns the client's verified sessions.

This PR simplifies the SDK's verification process by avoiding a second API call to retrieve the client's last touched session. Instead, it retrieves it from the list of the retrieved client sessions.