### PR TITLE
docs: Add better logging for clerk server errors, add troubleshooting…

### DIFF
--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -8,6 +8,8 @@ const port = process.env.PORT;
 
 var app = express();
 
+// Note: this is just a sample errorHandler that pipes clerk server errors through to your API responses
+// You will want to apply different handling in your own app to avoid exposing too much info to the client
 function errorHandler (err, req, res, next) {
   const statusCode = err.statusCode || 500;
   const body = err.data || { error: err.message };

--- a/src/Clerk.ts
+++ b/src/Clerk.ts
@@ -17,7 +17,7 @@ import { UserApi } from './apis/UserApi';
 // resources
 import { Session } from './resources/Session';
 
-import { HttpError } from './utils/Errors';
+import { HttpError, ClerkServerError } from './utils/Errors';
 
 const defaultApiKey = process.env.CLERK_API_KEY || '';
 const defaultApiVersion = process.env.CLERK_API_VERSION || 'v1';
@@ -136,13 +136,22 @@ export default class Clerk {
   // Middlewares
 
   // defaultOnError swallows the error
-  defaultOnError(error: Error) {
-    console.warn(error.message);
+  defaultOnError(error: Error & { data: any }) {
+    Logger.warn(error.message);
+
+    (error.data || []).forEach((serverError: ClerkServerError) => {
+      Logger.warn(serverError.longMessage);
+    });
   }
 
   // strictOnError returns the error so that Express will halt the request chain
-  strictOnError(error: Error) {
-    console.error(error.message);
+  strictOnError(error: Error & { data: any }) {
+    Logger.error(error.message);
+
+    (error.data || []).forEach((serverError: ClerkServerError) => {
+      Logger.error(serverError.longMessage);
+    });
+
     return error;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,11 @@ export {
 export { WithSessionProp, RequireSessionProp } from './instance';
 
 // Export Errors
-export { HttpError } from './utils/Errors';
+export { HttpError, ClerkServerError, ClerkServerErrorJSON } from './utils/Errors';
+
+// Export Logger
+import Logger from './utils/Logger';
+export { Logger };
 
 // Export setters for the default singleton instance
 // Useful if you only have access to a sub-api instance

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -5,7 +5,9 @@ export default Clerk;
 export { WithSessionProp, RequireSessionProp } from './Clerk';
 
 export { Nullable } from './resources/Nullable';
-export { HttpError } from './utils/Errors';
+export { HttpError, ClerkServerError, ClerkServerErrorJSON } from './utils/Errors';
+import Logger from './utils/Logger';
+export { Logger };
 export { Client } from './resources/Client';
 export { Email } from './resources/Email';
 export { EmailAddress } from './resources/EmailAddress';

--- a/src/utils/Deserializer.ts
+++ b/src/utils/Deserializer.ts
@@ -4,6 +4,7 @@ import { Email } from '../resources/Email';
 import { Session } from '../resources/Session';
 import { SMSMessage } from '../resources/SMSMessage';
 import { User } from '../resources/User';
+import Logger from './Logger';
 
 // FIXME don't return any
 export default function deserialize(data: any): any {
@@ -29,6 +30,6 @@ function jsonToObject(item: any): any {
     case ObjectType.SmsMessage:
       return SMSMessage.fromJSON(item);
     default:
-      console.log(`Unexpected object type: ${item.object}`);
+      Logger.error(`Unexpected object type: ${item.object}`);
   }
 }

--- a/src/utils/ErrorHandler.ts
+++ b/src/utils/ErrorHandler.ts
@@ -1,11 +1,18 @@
-// Just a pass-through of the error response code & body for no
-
-import { HttpError } from './Errors';
+import { HttpError, ClerkServerError, ClerkServerErrorJSON } from './Errors';
 
 export default function handleError(error: any): never {
   const statusCode = error?.response?.statusCode || 500;
   const message = error.message || '';
-  const data = error?.response?.body;
+  const body = error?.response?.body;
+  let data;
+
+  if (body && body.errors) {
+    data = (body.errors || []).map((errorJSON: ClerkServerErrorJSON) => {
+      return ClerkServerError.fromJSON(errorJSON);
+    });
+  } else {
+    data = body;
+  }
 
   throw new HttpError(statusCode, message, data);
 }

--- a/src/utils/Errors.ts
+++ b/src/utils/Errors.ts
@@ -8,3 +8,35 @@ export class HttpError extends Error {
     this.data = data;
   }
 }
+
+export interface ClerkServerErrorProps {
+  message: string;
+  longMessage: string;
+  code: string;
+}
+
+export interface ClerkServerErrorJSON {
+  message: string;
+  long_message: string;
+  code: string;
+}
+
+export class ClerkServerError {
+  public message: string;
+  public longMessage: string;
+  public code: string;
+
+  constructor(data: ClerkServerErrorProps) {
+    this.message = data.message;
+    this.longMessage = data.longMessage;
+    this.code = data.code;
+  }
+
+  static fromJSON(data: ClerkServerErrorJSON) {
+    return new ClerkServerError({
+      message: data.message,
+      longMessage: data.long_message,
+      code: data.code
+    });
+  }
+}

--- a/src/utils/RestClient.ts
+++ b/src/utils/RestClient.ts
@@ -5,7 +5,7 @@ import snakecaseKeys from 'snakecase-keys';
 import * as querystring from 'querystring';
 
 const packageName = '@clerk/clerk-sdk-node'; // TODO get from package.json
-const packageVersion = '0.4.0'; // TODO get from package.json
+const packageVersion = '0.4.1'; // TODO get from package.json
 const packageRepo = 'https://github.com/clerkinc/clerk-sdk-node';
 const userAgent = `${packageName}/${packageVersion} (${packageRepo})`;
 const contentType = 'application/x-www-form-urlencoded';


### PR DESCRIPTION
… section to readme, elaborate on Express custom error handlers

The built-in error handler will now parse Clerk server errors and pass them to the `data` field of the error.

Updated default middleware `onError` handlers to log the `long_message` of said server errors, if `CLERK_LOGGING` is set to `true`.