### PR TITLE
feat: Introduce middleware for networkless authentication 

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -89,3 +89,91 @@ test('expressRequireSession with no session cookie', async () => {
     expect(mockNext).toHaveBeenCalled();
     expect(mockNext.mock.calls[0][0]).toBeInstanceOf(Error);
 });
+
+test('expressWithNetworkless with valid token', async () => {
+    mockGet.mockImplementationOnce(() => { return 'foo'; });
+
+    // @ts-ignore
+    const req = { headers: { 'Authorization': 'token' } } as Request;
+    const res = {} as Response;
+
+    const claims = {
+        iss: 'issuer',
+        sub: 'subject',
+        aud: 'clerk',
+        name: 'name',
+        picture: 'picture'
+    }
+
+    const clerk = Clerk.getInstance();
+    clerk.verifyToken = jest.fn().mockReturnValue(claims);
+
+    await clerk.expressWithNetworkless()(req, res, mockNext as NextFunction);
+
+    // @ts-ignore
+    expect(req.claims).toEqual(claims);
+
+    expect(mockNext).toHaveBeenCalledWith(); // 0 args
+});
+
+test('expressWithNetworkless with no token', async () => {
+    mockGet.mockImplementationOnce(() => { return undefined; });
+
+    // @ts-ignore
+    const req = {} as Request;
+    const res = {} as Response;
+
+    const clerk = Clerk.getInstance();
+
+    await clerk.expressWithNetworkless()(req, res, mockNext as NextFunction);
+
+    // @ts-ignore
+    expect(req.claims).toBeUndefined();
+
+    expect(mockNext).toHaveBeenCalledWith(); // 0 args
+});
+
+test('expressRequireNetworkless with valid token', async () => {
+    mockGet.mockImplementationOnce(() => { return 'foo'; });
+
+    // @ts-ignore
+    const req = { headers: { 'Authorization': 'token' } } as Request;
+    const res = {} as Response;
+
+    const claims = {
+        iss: 'issuer',
+        sub: 'subject',
+        aud: 'clerk',
+        name: 'name',
+        picture: 'picture'
+    }
+
+    const clerk = Clerk.getInstance();
+    clerk.verifyToken = jest.fn().mockReturnValue(claims);
+
+    await clerk.expressRequireNetworkless()(req, res, mockNext as NextFunction);
+
+    // @ts-ignore
+    expect(req.claims).toEqual(claims);
+
+    expect(mockNext).toHaveBeenCalledWith(); // 0 args
+});
+
+test('expressRequireNetworkless with no token', async () => {
+    mockGet.mockImplementationOnce(() => { return undefined; });
+
+    // @ts-ignore
+    const req = {} as Request;
+    const res = {} as Response;
+
+    const clerk = Clerk.getInstance();
+
+    await clerk.expressRequireNetworkless()(req, res, mockNext as NextFunction);
+
+    // @ts-ignore
+    expect(req.claims).toBeUndefined();
+
+    expect(mockNext).toHaveBeenCalled();
+    expect(mockNext.mock.calls[0][0]).toBeInstanceOf(Error);
+});
+


### PR DESCRIPTION
This PR introduces a new middleware to use with the upcoming networkless authentication that retrieves a JWT token from the Authorization header or cookie and tries to verify it. If successful adds the JWT claims in the request somebody can easily access them inside a handler

This PR must be merged after #24 