### PR TITLE
fix: Throw on not found CLERK_API_KEY

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,8 @@
 module.exports = {
-  "roots": [
-    "<rootDir>/src"
-  ],
-  "testMatch": [
-    "**/?(*.)+(spec|test).+(ts|tsx|js)"
-  ],
-  "transform": {
-    "^.+\\.(ts|tsx)$": "ts-jest"
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/?(*.)+(spec|test).+(ts|tsx|js)'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
   },
-}
+  setupFiles: ['<rootDir>/jest/setupEnvVars.js'],
+};

--- a/jest/setupEnvVars.js
+++ b/jest/setupEnvVars.js
@@ -1,0 +1,1 @@
+process.env.CLERK_API_KEY = 'TEST_API_KEY';

--- a/src/Clerk.ts
+++ b/src/Clerk.ts
@@ -19,6 +19,7 @@ import { UserApi } from './apis/UserApi';
 import { Session } from './resources/Session';
 
 import { ClerkServerError } from './utils/Errors';
+import { SupportMessages } from './constants/SupportMessages';
 
 const defaultApiKey = process.env.CLERK_API_KEY || '';
 const defaultApiVersion = process.env.CLERK_API_VERSION || 'v1';
@@ -62,6 +63,11 @@ export default class Clerk {
     httpOptions?: object;
     jwksCacheMaxAge?: number;
   } = {}) {
+
+    if(!apiKey){
+      throw Error(SupportMessages.API_KEY_NOT_FOUND);
+    }
+
     this._restClient = new RestClient(
       apiKey,
       serverApiUrl,

--- a/src/constants/SupportMessages.ts
+++ b/src/constants/SupportMessages.ts
@@ -1,0 +1,6 @@
+export const SupportMessages = {
+  API_KEY_NOT_FOUND: `
+Clerk API key not found during initialization.
+Please visit https://github.com/clerkinc/clerk-sdk-node#options--env-vars-available for more information.
+    `,
+};


### PR DESCRIPTION
- [x] Throw on initialization without the API key being set.
- [x] Add SupportMessages structure in preparation for better message logging.
- [x] Added setupFiles for more controlled testing.

For now IMO this is "good enough" until we create a proper logging infrastructure:
![image](https://user-images.githubusercontent.com/15251081/140505934-29708491-5dd2-47c1-acb7-1b0cdfb70816.png)
