### PR TITLE
fix: Add the capability of custom Clerk object with API key through /instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ warm fuzzy feeling of controlling instantiation yourself:
 #### ESM
 
 ```ts
-import { Clerk } from '@clerk/clerk-sdk-node';
+import Clerk from '@clerk/clerk-sdk-node/instance';
 
 const clerk = new Clerk({ apiKey: 'top-secret' });
 
@@ -222,8 +222,7 @@ const clientList = await clerk.clients.getClientList();
 #### CJS
 
 ```ts
-const pkg = require('@clerk/clerk-sdk-node');
-const { Clerk } = pkg;
+const Clerk = require('@clerk/clerk-sdk-node/instance').default;
 
 const clerk = new Clerk({ apiKey: 'your-eyes-only' });
 

--- a/instance.d.ts
+++ b/instance.d.ts
@@ -1,0 +1,2 @@
+export * from './dist/instance'
+export { default } from './dist/instance'

--- a/instance.js
+++ b/instance.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/instance')

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "main": "dist/index.js",
   "module": "esm/index.js",
   "typings": "dist/index.d.ts",
-  "exports": {
-    "import": "./esm/index.js",
-    "require": "./dist/index.js"
-  },
+  "files": ["dist", "esm", "instance.js", "instance.d.ts", "package.json"],
   "engines": {
     "node": ">=12"
   },

--- a/src/__tests__/instance.test.ts
+++ b/src/__tests__/instance.test.ts
@@ -1,0 +1,25 @@
+const TEST_API_KEY = 'TEST_API_KEY';
+
+describe('Custom Clerk instance initialization', () => {
+  test('throw error when initialized without apiKey', () => {
+    /** In this case we are resetting jest module cache */
+    jest.resetModules();
+    process.env = {};
+    const Clerk = require('../instance').default;
+    expect(() => new Clerk()).toThrow(Error);
+  });
+
+  test('with custom apiKey', () => {
+    jest.resetModules();
+    process.env = {};
+    const Clerk = require('../instance').default;
+    expect(() => new Clerk({ apiKey: TEST_API_KEY })).not.toThrow(Error);
+  });
+
+  test('fallback to process.env for apiKey', () => {
+    jest.resetModules();
+    process.env.CLERK_API_KEY = TEST_API_KEY;
+    const Clerk = require('../instance').default;
+    expect(() => new Clerk()).not.toThrow(Error);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
 import Clerk from './instance';
 
-// Export as a named export in case the dev wishes to create Clerk instances as well
-export { Clerk };
-
 const singletonInstance = Clerk.getInstance();
 const clients = singletonInstance.clients;
 const emails = singletonInstance.emails;


### PR DESCRIPTION
Possible fix for #45 

Check the new Readme about how we can instantiate a new Clerk instance with custom attributes. 
Check instance tests for how the expected cases.