### PR TITLE
feat: Invitations API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This SDK allows you to call the Clerk server API from node / JS / TS code withou
 yourself.
 
 To gain a better understanding of the underlying API calls the SDK makes, feel free to consult
-the <a href="https://docs.clerk.dev/backend/introduction" target="_blank">official Clerk server API documentation</a>.
+the <a href="https://docs.clerk.dev/reference/backend-api-reference" target="_blank">official Clerk server API documentation</a>.
 
 ## Table of contents
 
@@ -30,6 +30,10 @@ the <a href="https://docs.clerk.dev/backend/introduction" target="_blank">offici
     - [getClientList()](#getclientlist)
     - [getClient(clientId)](#getclientclientid)
     - [verifyClient(sessionToken)](#verifyclientsessiontoken)
+  - [Invitation operations](#invitation-operations)
+    - [getInvitationList()](#getinvitationlist)
+    - [createInvitation(params)](#createinvitationparams)
+    - [revokeInvitation(invitationId)](#revokeinvitationinvitationId)
   - [Session operations](#session-operations)
     - [getSessionList({ clientId, userId })](#getsessionlist-clientid-userid-)
     - [getSession(sessionId)](#getsessionsessionid)
@@ -265,6 +269,40 @@ Retrieves a client for a given session token, if the session is active:
 ```ts
 const sessionToken = 'my-session-token';
 const client = await clerk.clients.verifyClient(sessionToken);
+```
+
+### Invitation operations
+
+Invitation operations are exposed by the `invitations` sub-api (`clerk.invitations`).
+
+#### getInvitationList()
+
+Retrieves a list of all non-revoked invitations for your application, sorted by descending creation date.
+
+```ts
+const invitations = await clerk.invitations.getInvitationList();
+```
+
+#### createInvitation(params)
+
+Creates a new invitation for the given email address and sends the invitation email.
+
+Keep in mind that you cannot create an invitation if there is already one for the given email address. Also, trying to create an invitation for an email address that already exists in your application will result in an error.
+
+```js
+const invitation = await clerk.invitations.createInvitation({
+  emailAddress: "invite@example.com",
+});
+```
+
+#### revokeInvitation(invitationId)
+
+Revokes the invitation with the provided `invitationId`. Revoking an invitation makes the invitation email link unusable. However, it doesn't prevent the user from signing up if they follow the sign up flow.
+
+Only active (i.e. non-revoked) invitations can be revoked.
+
+```js
+const invitation = await clerk.invitations.revokeInvitation("inv_some-id");
 ```
 
 ### Session operations

--- a/examples/node/src/invitations.ts
+++ b/examples/node/src/invitations.ts
@@ -1,0 +1,27 @@
+// Usage:
+// From examples/node, transpile files by running `tsc`
+// To run:
+// node --require dotenv/config dist/invitations.js
+
+import { setClerkServerApiUrl, invitations } from '@clerk/clerk-sdk-node';
+
+const serverApiUrl = process.env.CLERK_API_URL || '';
+
+setClerkServerApiUrl(serverApiUrl);
+
+// Create an invitation
+await invitations.createInvitation({
+  emailAddress: 'test@example.com',
+});
+
+// Create another invitation
+const { id } = await invitations.createInvitation({
+  emailAddress: 'will-be-revoked@example.com',
+});
+
+// Revoke the last invitation
+await invitations.revokeInvitation(String(id));
+
+// Get invitation list
+let invitationList = await invitations.getInvitationList();
+console.log(invitationList);

--- a/src/__tests__/Clerk.test.ts
+++ b/src/__tests__/Clerk.test.ts
@@ -1,6 +1,7 @@
 import Clerk from '../Clerk';
 import { ClientApi } from '../apis/ClientApi';
 import { EmailApi } from '../apis/EmailApi';
+import { InvitationApi } from '../apis/InvitationApi';
 import { SessionApi } from '../apis/SessionApi';
 import { SMSMessageApi } from '../apis/SMSMessageApi';
 import { UserApi } from '../apis/UserApi';
@@ -42,6 +43,17 @@ test('emails getter returns the same instance every time', () => {
   const emails = Clerk.getInstance().emails;
   const emails2 = Clerk.getInstance().emails;
   expect(emails2).toBe(emails);
+});
+
+test('invitations getter returns an Invation API instance', () => {
+  const invitations = Clerk.getInstance().invitations;
+  expect(invitations).toBeInstanceOf(InvitationApi);
+});
+
+test('invitations getter returns the same instance every time', () => {
+  const invitations = Clerk.getInstance().invitations;
+  const invitations2 = Clerk.getInstance().invitations;
+  expect(invitations2).toBe(invitations);
 });
 
 test('sessions getter returns a Session API instance', () => {

--- a/src/__tests__/apis/InvitationApi.test.ts
+++ b/src/__tests__/apis/InvitationApi.test.ts
@@ -1,0 +1,67 @@
+import nock from 'nock';
+import { invitations, Invitation } from '../../index';
+
+test('getInvitationList() returns a list of invitations', async () => {
+  nock('https://api.clerk.dev')
+    .get('/v1/invitations')
+    .replyWithFile(200, __dirname + '/responses/getInvitationList.json', {});
+
+  const invitationList = await invitations.getInvitationList();
+  expect(invitationList).toBeInstanceOf(Array);
+  expect(invitationList.length).toEqual(1);
+  expect(invitationList[0]).toBeInstanceOf(Invitation);
+});
+
+test('createInvitation() creates an invitation', async () => {
+  const emailAddress = 'test@example.com';
+  const resJSON = {
+    object: 'invitation',
+    id: 'inv_randomid',
+    email_address: emailAddress,
+    created_at: 1611948436,
+    updated_at: 1611948436,
+  };
+
+  nock('https://api.clerk.dev')
+    .post('/v1/invitations', {
+      email_address: emailAddress,
+    })
+    .reply(200, resJSON);
+
+  const invitation = await invitations.createInvitation({
+    emailAddress,
+  });
+  expect(invitation).toEqual(
+    new Invitation({
+      id: resJSON.id,
+      emailAddress,
+      createdAt: resJSON.created_at,
+      updatedAt: resJSON.updated_at,
+    })
+  );
+});
+
+test('revokeInvitation() revokes an invitation', async () => {
+  const id = 'inv_randomid';
+  const resJSON = {
+    object: 'invitation',
+    id,
+    email_address: 'test@example.com',
+    created_at: 1611948436,
+    updated_at: 1611948436,
+  };
+
+  nock('https://api.clerk.dev')
+    .post(`/v1/invitations/${id}/revoke`)
+    .reply(200, resJSON);
+
+  const invitation = await invitations.revokeInvitation(id);
+  expect(invitation).toEqual(
+    new Invitation({
+      id,
+      emailAddress: resJSON.email_address,
+      createdAt: resJSON.created_at,
+      updatedAt: resJSON.updated_at,
+    })
+  );
+});

--- a/src/__tests__/apis/responses/getInvitationList.json
+++ b/src/__tests__/apis/responses/getInvitationList.json
@@ -1,0 +1,10 @@
+[
+  {
+    "object": "invitation",
+    "id": "inv_randomid",
+    "email_address": "kyle@tech.com",
+    "created_at": 1611948436,
+    "updated_at": 1611948436
+  }
+]
+

--- a/src/__tests__/utils/Deserializer.test.ts
+++ b/src/__tests__/utils/Deserializer.test.ts
@@ -2,6 +2,7 @@ import deserialize from '../../utils/Deserializer';
 
 import { Client } from '../../resources/Client';
 import { Email } from '../../resources/Email';
+import { Invitation } from '../../resources/Invitation';
 import { Session } from '../../resources/Session';
 import { SMSMessage } from '../../resources/SMSMessage';
 // import { User } from '../../resources/User';
@@ -24,9 +25,16 @@ const emailJSON = {
   to_email_address: 'accounting@cyberdyne.com',
   email_address_id: 'idn_snafu',
   subject: 'Business trip reimbursement',
-  body:
-    'Please find attached the invoices for expenses made during the visit to NY.',
+  body: 'Please find attached the invoices for expenses made during the visit to NY.',
   status: 'queued',
+};
+
+const invitationJSON = {
+  object: 'invitation',
+  id: 'inv_randomid',
+  email_address: 'invitation@example.com',
+  created_at: 1612378465,
+  updated_at: 1612378465,
 };
 
 const sessionJSON = {
@@ -65,6 +73,18 @@ test('deserializes an array of Client objects', () => {
 test('deserializes an Email object', () => {
   const email = deserialize(emailJSON);
   expect(email).toBeInstanceOf(Email);
+});
+
+test('deserializes an Invitation object', () => {
+  const invitation = deserialize(invitationJSON);
+  expect(invitation).toBeInstanceOf(Invitation);
+});
+
+test('deserializes an array of Invitation objects', () => {
+  const invitations = deserialize([invitationJSON]);
+  expect(invitations).toBeInstanceOf(Array);
+  expect(invitations.length).toBe(1);
+  expect(invitations[0]).toBeInstanceOf(Invitation);
 });
 
 test('deserializes a Session object', () => {

--- a/src/apis/InvitationApi.ts
+++ b/src/apis/InvitationApi.ts
@@ -1,0 +1,32 @@
+import { AbstractApi } from './AbstractApi';
+import { Invitation } from '../resources/Invitation';
+
+const basePath = '/invitations';
+
+type CreateParams = {
+  emailAddress: string;
+};
+
+export class InvitationApi extends AbstractApi {
+  public async getInvitationList(): Promise<Array<Invitation>> {
+    return this._restClient.makeRequest({
+      method: 'get',
+      path: basePath,
+    });
+  }
+
+  public async createInvitation(params: CreateParams): Promise<Invitation> {
+    return this._restClient.makeRequest({
+      method: 'post',
+      path: basePath,
+      bodyParams: params,
+    });
+  }
+
+  public async revokeInvitation(invitationId: string): Promise<Invitation> {
+    return this._restClient.makeRequest({
+      method: 'post',
+      path: `${basePath}/${invitationId}/revoke`,
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import Clerk from './instance';
 const singletonInstance = Clerk.getInstance();
 const clients = singletonInstance.clients;
 const emails = singletonInstance.emails;
+const invitations = singletonInstance.invitations;
 const sessions = singletonInstance.sessions;
 const smsMessages = singletonInstance.smsMessages;
 const users = singletonInstance.users;
@@ -11,7 +12,7 @@ const users = singletonInstance.users;
 export default singletonInstance;
 
 // Export sub-api objects
-export { clients, emails, sessions, smsMessages, users };
+export { clients, emails, invitations, sessions, smsMessages, users };
 
 // Export resources
 export {
@@ -21,6 +22,7 @@ export {
   EmailAddress,
   ExternalAccount,
   IdentificationLink,
+  Invitation,
   PhoneNumber,
   Session,
   SMSMessage,
@@ -29,12 +31,10 @@ export {
 } from './instance';
 
 // Export middleware functions
-const ClerkExpressWithSession = singletonInstance.expressWithSession.bind(
-  singletonInstance
-);
-const ClerkExpressRequireSession = singletonInstance.expressRequireSession.bind(
-  singletonInstance
-);
+const ClerkExpressWithSession =
+  singletonInstance.expressWithSession.bind(singletonInstance);
+const ClerkExpressRequireSession =
+  singletonInstance.expressRequireSession.bind(singletonInstance);
 const withSession = singletonInstance.withSession.bind(singletonInstance);
 const requireSession = singletonInstance.requireSession.bind(singletonInstance);
 export {
@@ -45,10 +45,19 @@ export {
 };
 
 // Export wrapper types for Next.js requests
-export { WithSessionProp, RequireSessionProp, WithSessionClaimsProp, RequireSessionClaimsProp } from './instance';
+export {
+  WithSessionProp,
+  RequireSessionProp,
+  WithSessionClaimsProp,
+  RequireSessionClaimsProp,
+} from './instance';
 
 // Export Errors
-export { HttpError, ClerkServerError, ClerkServerErrorJSON } from './utils/Errors';
+export {
+  HttpError,
+  ClerkServerError,
+  ClerkServerErrorJSON,
+} from './utils/Errors';
 
 // Export Logger
 import Logger from './utils/Logger';

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -2,10 +2,19 @@ import Clerk from './Clerk';
 
 export default Clerk;
 
-export { WithSessionProp, RequireSessionProp, WithSessionClaimsProp, RequireSessionClaimsProp } from './Clerk';
+export {
+  WithSessionProp,
+  RequireSessionProp,
+  WithSessionClaimsProp,
+  RequireSessionClaimsProp,
+} from './Clerk';
 
 export { Nullable } from './resources/Nullable';
-export { HttpError, ClerkServerError, ClerkServerErrorJSON } from './utils/Errors';
+export {
+  HttpError,
+  ClerkServerError,
+  ClerkServerErrorJSON,
+} from './utils/Errors';
 import Logger from './utils/Logger';
 export { Logger };
 export { Client } from './resources/Client';
@@ -13,6 +22,7 @@ export { Email } from './resources/Email';
 export { EmailAddress } from './resources/EmailAddress';
 export { ExternalAccount } from './resources/ExternalAccount';
 export { IdentificationLink } from './resources/IdentificationLink';
+export { Invitation } from './resources/Invitation';
 export { PhoneNumber } from './resources/PhoneNumber';
 export { Session } from './resources/Session';
 export { SMSMessage } from './resources/SMSMessage';

--- a/src/resources/Invitation.ts
+++ b/src/resources/Invitation.ts
@@ -1,0 +1,25 @@
+import camelcaseKeys from 'camelcase-keys';
+import filterKeys from '../utils/Filter';
+
+import type { InvitationJSON } from './JSON';
+import type { InvitationProps } from './Props';
+
+interface InvitationPayload extends InvitationProps {}
+
+export interface Invitation extends InvitationPayload {}
+
+export class Invitation {
+  static attributes = ['id', 'emailAddress', 'createdAt', 'updatedAt'];
+
+  static defaults = [];
+
+  constructor(data: Partial<InvitationProps> = {}) {
+    Object.assign(this, Invitation.defaults, data);
+  }
+
+  static fromJSON(data: InvitationJSON): Invitation {
+    const camelcased = camelcaseKeys(data);
+    const filtered = filterKeys(camelcased, Invitation.attributes);
+    return new Invitation(filtered as InvitationPayload);
+  }
+}

--- a/src/resources/JSON.ts
+++ b/src/resources/JSON.ts
@@ -14,6 +14,7 @@ export enum ObjectType {
   FacebookAccount = 'facebook_account',
   GoogleAccount = 'google_account',
   ExternalAccount = 'external_account',
+  Invitation = 'invitation',
   PhoneNumber = 'phone_number',
   Session = 'session',
   SignInAttempt = 'sign_in_attempt',
@@ -87,10 +88,20 @@ export interface ExtAccountJSON extends ClerkResourceJSON {
   avatar_url: string;
 }
 
-export type ExternalAccountJSON = FacebookAccountJSON | GoogleAccountJSON | ExtAccountJSON;
+export type ExternalAccountJSON =
+  | FacebookAccountJSON
+  | GoogleAccountJSON
+  | ExtAccountJSON;
 
 export interface IdentificationLinkJSON extends ClerkResourceJSON {
   type: string;
+}
+
+export interface InvitationJSON extends ClerkResourceJSON {
+  object: ObjectType.Invitation;
+  email_address: string;
+  created_at: number;
+  updated_at: number;
 }
 
 export interface PhoneNumberJSON extends ClerkResourceJSON {

--- a/src/resources/Props.ts
+++ b/src/resources/Props.ts
@@ -52,6 +52,12 @@ export interface IdentificationLinkProps extends ClerkProps {
   type: Nullable<string>;
 }
 
+export interface InvitationProps extends ClerkProps {
+  emailAddress: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export interface PhoneNumberProps extends ClerkProps {
   phoneNumber: Nullable<string>;
   // verification: Nullable<VerificationProps>;

--- a/src/resources/User.ts
+++ b/src/resources/User.ts
@@ -25,7 +25,7 @@ export class User {
     'profileImageUrl', 'primaryEmailAddressId', 'primaryEmailAddressId', 'primaryPhoneNumberId',
     'passwordEnabled', 'twoFactorEnabled', 'passwordEnabled', 'passwordEnabled', 'passwordEnabled',
     'twoFactorEnabled', 'publicMetadata', 'privateMetadata', 'createdAt', 'updatedAt'];
-  
+
   static associations = {
     emailAddresses: Association.HasMany,
     phoneNumbers: Association.HasMany,

--- a/src/utils/Deserializer.ts
+++ b/src/utils/Deserializer.ts
@@ -1,6 +1,7 @@
 import { ObjectType } from '../resources/JSON';
 import { Client } from '../resources/Client';
 import { Email } from '../resources/Email';
+import { Invitation } from '../resources/Invitation';
 import { Session } from '../resources/Session';
 import { SMSMessage } from '../resources/SMSMessage';
 import { User } from '../resources/User';
@@ -9,7 +10,7 @@ import Logger from './Logger';
 // FIXME don't return any
 export default function deserialize(data: any): any {
   if (Array.isArray(data)) {
-    return data.map(item => jsonToObject(item));
+    return data.map((item) => jsonToObject(item));
   } else {
     return jsonToObject(data);
   }
@@ -23,6 +24,8 @@ function jsonToObject(item: any): any {
       return Client.fromJSON(item);
     case ObjectType.Email:
       return Email.fromJSON(item);
+    case ObjectType.Invitation:
+      return Invitation.fromJSON(item);
     case ObjectType.User:
       return User.fromJSON(item);
     case ObjectType.Session:


### PR DESCRIPTION
Added support for invitations related operations. Available actions:
- createInvitation(): Create a new invitation and send an email.
- getInvitationList(): Return a list of non-revoked invitations, sorted
  by creation date.
- revokeInvitation(): Revoke an invitation, making the email link
  unusable.