### PR TITLE
fix: Allow redirectUrl in invitations.create()

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,9 +332,12 @@ Creates a new invitation for the given email address and sends the invitation em
 
 Keep in mind that you cannot create an invitation if there is already one for the given email address. Also, trying to create an invitation for an email address that already exists in your application will result in an error.
 
+You can optionally pass a `redirectUrl` parameter when creating the invitation and the invitee will be redirected there after they click the invitation email link.
+
 ```js
 const invitation = await clerk.invitations.createInvitation({
   emailAddress: "invite@example.com",
+  redirectUrl: "https://optionally-redirect-here",
 });
 ```
 

--- a/src/__tests__/apis/InvitationApi.test.ts
+++ b/src/__tests__/apis/InvitationApi.test.ts
@@ -41,6 +41,38 @@ test('createInvitation() creates an invitation', async () => {
   );
 });
 
+test('createInvitation() accepts a redirectUrl', async () => {
+  const emailAddress = 'test@example.com';
+  const resJSON = {
+    object: 'invitation',
+    id: 'inv_randomid',
+    email_address: emailAddress,
+    created_at: 1611948436,
+    updated_at: 1611948436,
+  };
+  const redirectUrl = 'http://redirect.org';
+
+  nock('https://api.clerk.dev')
+    .post('/v1/invitations', {
+      email_address: emailAddress,
+      redirect_url: redirectUrl,
+    })
+    .reply(200, resJSON);
+
+  const invitation = await invitations.createInvitation({
+    emailAddress,
+    redirectUrl,
+  });
+  expect(invitation).toEqual(
+    new Invitation({
+      id: resJSON.id,
+      emailAddress,
+      createdAt: resJSON.created_at,
+      updatedAt: resJSON.updated_at,
+    })
+  );
+});
+
 test('revokeInvitation() revokes an invitation', async () => {
   const id = 'inv_randomid';
   const resJSON = {

--- a/src/apis/InvitationApi.ts
+++ b/src/apis/InvitationApi.ts
@@ -5,6 +5,7 @@ const basePath = '/invitations';
 
 type CreateParams = {
   emailAddress: string;
+  redirectUrl?: string;
 };
 
 export class InvitationApi extends AbstractApi {


### PR DESCRIPTION
When creating an invitation, you can optionally pass the `redirectUrl` for the link in the email that will be sent out to the invitee.

Added support for the `redirectUrl` parameter in the invitations API `create()` method.