### PR TITLE
Check blank ID in single resource fetch requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ const allowlistIdentifier = await createAllowlistIdentifier({
 
 #### deleteAllowlistIdentifier(allowlistIdentifierId)
 
-Deletes an allowlist identifier, specified by the `allowlistIdentifierId` parameter.
+Deletes an allowlist identifier, specified by the `allowlistIdentifierId` parameter. Throws an error if the `allowlistIdentifierId` parameter is invalid.
 
 ```ts
 await deleteAllowlistIdentifier("alid_randomid");
@@ -298,7 +298,7 @@ const clients = await clerk.clients.getClientList();
 
 #### getClient(clientId)
 
-Retrieves a single client by its id:
+Retrieves a single client by its id, if the id is valid. Throws an error otherwise.
 
 ```ts
 const clientID = 'my-client-id';
@@ -343,7 +343,9 @@ const invitation = await clerk.invitations.createInvitation({
 
 #### revokeInvitation(invitationId)
 
-Revokes the invitation with the provided `invitationId`. Revoking an invitation makes the invitation email link unusable. However, it doesn't prevent the user from signing up if they follow the sign up flow.
+Revokes the invitation with the provided `invitationId`. Throws an error if `invitationId` is invalid.
+
+Revoking an invitation makes the invitation email link unusable. However, it doesn't prevent the user from signing up if they follow the sign up flow.
 
 Only active (i.e. non-revoked) invitations can be revoked.
 
@@ -373,7 +375,7 @@ const sessions = await clerk.sessions.getSessionList({ clientId, sessionId });
 
 #### getSession(sessionId)
 
-Retrieves a single session by its id:
+Retrieves a single session by its id, if the id is valid. Throws an error otherwise.
 
 ```ts
 const session = await clerk.sessions.getSession(sessionId);
@@ -381,7 +383,9 @@ const session = await clerk.sessions.getSession(sessionId);
 
 #### revokeSession(sessionId)
 
-Revokes a session given its id. User will be signed out from the particular client the referred to:
+Revokes a session given its id, if the id is valid. Throws an error otherwise.
+
+User will be signed out from the particular client the referred to.
 
 ```ts
 const sessionId = 'my-session-id';
@@ -390,7 +394,7 @@ const session = await clerk.sessions.revokeSession(sessionId);
 
 #### verifySession(sessionId, sessionToken)
 
-Verifies whether a session with a given id corresponds to the provided session token:
+Verifies whether a session with a given id corresponds to the provided session token. Throws an error if the provided id is invalid.
 
 ```ts
 const sessionId = 'my-session-id';
@@ -431,7 +435,7 @@ If these filters are included, the response will contain only users that own any
 
 #### getUser(userId)
 
-Retrieves a single user by their id:
+Retrieves a single user by their id, if the id is valid. Throws an error otherwise.
 
 ```ts
 const userId = 'my-user-id';
@@ -440,7 +444,9 @@ const user = await clerk.users.getUser(userId);
 
 #### updateUser(userId, params)
 
-Updates a user with a given id with attribute values provided in a params object:
+Updates a user with a given id with attribute values provided in a params object.
+
+The provided id must be valid, otherwise an error will be thrown.
 
 ```ts
 const userId = 'my-user-id';
@@ -462,7 +468,7 @@ Supported user attributes for update are:
 
 #### deleteUser(userId)
 
-Deletes a user given their id:
+Deletes a user given their id, if the id is valid. Throws an error otherwise.
 
 ```ts
 const userId = 'my-user-id';

--- a/src/__tests__/apis/AllowlistIdentifierApi.test.ts
+++ b/src/__tests__/apis/AllowlistIdentifierApi.test.ts
@@ -74,3 +74,9 @@ test('deleteAllowlistIdentifier() deletes an allowlist identifier', async () => 
     })
   );
 });
+
+test('deleteAllowlistIdentifier() throws an error without allowlist identifier ID', async () => {
+  await expect(
+    allowlistIdentifiers.deleteAllowlistIdentifier('')
+  ).rejects.toThrow('A valid ID is required.');
+});

--- a/src/__tests__/apis/ClientApi.test.ts
+++ b/src/__tests__/apis/ClientApi.test.ts
@@ -16,15 +16,17 @@ test('getClientList() returns a list of clients', async () => {
   const expected1 = new Client({
     id: 'client_isalwaysright',
     sessionIds: ['sess_swag'],
-    sessions: [{
-      id: 'sess_swag',
-      clientId: 'client_isalwaysright',
-      userId: 'user_player1',
-      status: 'active',
-      lastActiveAt: 1610706634,
-      expireAt: 1630846634,
-      abandonAt: 1630846634
-    }],
+    sessions: [
+      {
+        id: 'sess_swag',
+        clientId: 'client_isalwaysright',
+        userId: 'user_player1',
+        status: 'active',
+        lastActiveAt: 1610706634,
+        expireAt: 1630846634,
+        abandonAt: 1630846634,
+      },
+    ],
     signInAttemptId: null,
     signUpAttemptId: null,
     lastActiveSessionId: 'sess_swag',
@@ -35,15 +37,17 @@ test('getClientList() returns a list of clients', async () => {
   const expected2 = new Client({
     id: 'client_keysersoze',
     sessionIds: ['sess_mood'],
-    sessions: [{
-      id: 'sess_mood',
-      clientId: 'client_keysersoze',
-      userId: 'user_player2',
-      status: 'active',
-      lastActiveAt: 1610706634,
-      expireAt: 1630846634,
-      abandonAt: 1630846634
-    }],
+    sessions: [
+      {
+        id: 'sess_mood',
+        clientId: 'client_keysersoze',
+        userId: 'user_player2',
+        status: 'active',
+        lastActiveAt: 1610706634,
+        expireAt: 1630846634,
+        abandonAt: 1630846634,
+      },
+    ],
     signInAttemptId: 'sia_qwerty',
     signUpAttemptId: null,
     lastActiveSessionId: null,
@@ -59,15 +63,17 @@ test('getClient() returns a single client', async () => {
   const expected = new Client({
     id: 'client_server',
     sessionIds: ['sess_onthebeach'],
-    sessions: [{
-      id: 'sess_onthebeach',
-      clientId: 'client_server',
-      userId: 'user_player1',
-      status: 'active',
-      lastActiveAt: 1610706634,
-      expireAt: 1630846634,
-      abandonAt: 1630846634,
-    }],
+    sessions: [
+      {
+        id: 'sess_onthebeach',
+        clientId: 'client_server',
+        userId: 'user_player1',
+        status: 'active',
+        lastActiveAt: 1610706634,
+        expireAt: 1630846634,
+        abandonAt: 1630846634,
+      },
+    ],
     signInAttemptId: 'sia_cheepthrills',
     signUpAttemptId: null,
     lastActiveSessionId: null,
@@ -86,19 +92,27 @@ test('getClient() returns a single client', async () => {
   expect(client).toEqual(expected);
 });
 
+test('getClient() throws an error without client ID', async () => {
+  await expect(clients.getClient('')).rejects.toThrow(
+    'A valid ID is required.'
+  );
+});
+
 test('verifyClient() returns a client if verified', async () => {
   const expected = new Client({
     id: 'client_server',
     sessionIds: ['sess_onthebeach'],
-    sessions: [{
-      id: 'sess_onthebeach',
-      clientId: 'client_server',
-      userId: 'user_player1',
-      status: 'active',
-      lastActiveAt: 1610706634,
-      expireAt: 1630846634,
-      abandonAt: 1630846634,
-    }],
+    sessions: [
+      {
+        id: 'sess_onthebeach',
+        clientId: 'client_server',
+        userId: 'user_player1',
+        status: 'active',
+        lastActiveAt: 1610706634,
+        expireAt: 1630846634,
+        abandonAt: 1630846634,
+      },
+    ],
     signInAttemptId: 'sia_cheepthrills',
     signUpAttemptId: null,
     lastActiveSessionId: null,

--- a/src/__tests__/apis/InvitationApi.test.ts
+++ b/src/__tests__/apis/InvitationApi.test.ts
@@ -97,3 +97,9 @@ test('revokeInvitation() revokes an invitation', async () => {
     })
   );
 });
+
+test('revokeInvitation() throws an error without invitation ID', async () => {
+  await expect(invitations.revokeInvitation('')).rejects.toThrow(
+    'A valid ID is required.'
+  );
+});

--- a/src/__tests__/apis/SessionApi.test.ts
+++ b/src/__tests__/apis/SessionApi.test.ts
@@ -59,6 +59,18 @@ test('getSession() returns a single session', async () => {
   expect(session).toEqual(expected);
 });
 
+test('getSession() throws an error without session ID', async () => {
+  await expect(sessions.getSession('')).rejects.toThrow(
+    'A valid ID is required.'
+  );
+});
+
+test('revokeSession() throws an error without session ID', async () => {
+  await expect(sessions.revokeSession('')).rejects.toThrow(
+    'A valid ID is required.'
+  );
+});
+
 test('verifySession() returns a session if verified', async () => {
   const expected = new Session({
     id: 'sess_oops',
@@ -86,4 +98,10 @@ test('verifySession() returns a session if verified', async () => {
   );
 
   expect(session).toEqual(expected);
+});
+
+test('verifySession() throws an error without session ID', async () => {
+  await expect(sessions.verifySession('', '')).rejects.toThrow(
+    'A valid ID is required.'
+  );
 });

--- a/src/__tests__/apis/UserApi.test.ts
+++ b/src/__tests__/apis/UserApi.test.ts
@@ -118,3 +118,17 @@ test('getUser() returns a single user', async () => {
   const expectedPublicMetadata = { zodiac_sign: 'leo', ascendant: 'scorpio' };
   expect(user.publicMetadata).toEqual(expectedPublicMetadata);
 });
+
+test('getUser() throws an error without user ID', async () => {
+  await expect(users.getUser('')).rejects.toThrow('A valid ID is required.');
+});
+
+test('updateUser() throws an error without user ID', async () => {
+  await expect(users.updateUser('', {})).rejects.toThrow(
+    'A valid ID is required.'
+  );
+});
+
+test('deleteUser() throws an error without user ID', async () => {
+  await expect(users.deleteUser('')).rejects.toThrow('A valid ID is required.');
+});

--- a/src/apis/AbstractApi.ts
+++ b/src/apis/AbstractApi.ts
@@ -6,4 +6,10 @@ export abstract class AbstractApi {
   constructor(restClient: RestClient) {
     this._restClient = restClient;
   }
+
+  protected requireId(id: string) {
+    if (!id) {
+      throw new Error('A valid ID is required.');
+    }
+  }
 }

--- a/src/apis/AllowlistIdentifierApi.ts
+++ b/src/apis/AllowlistIdentifierApi.ts
@@ -31,6 +31,7 @@ export class AllowlistIdentifierApi extends AbstractApi {
   public async deleteAllowlistIdentifier(
     allowlistIdentifierId: string
   ): Promise<AllowlistIdentifier> {
+    this.requireId(allowlistIdentifierId);
     return this._restClient.makeRequest({
       method: 'delete',
       path: `${basePath}/${allowlistIdentifierId}`,

--- a/src/apis/ClientApi.ts
+++ b/src/apis/ClientApi.ts
@@ -10,6 +10,7 @@ export class ClientApi extends AbstractApi {
   }
 
   public async getClient(clientId: string): Promise<Client> {
+    this.requireId(clientId);
     return this._restClient.makeRequest({
       method: 'get',
       path: `/clients/${clientId}`,

--- a/src/apis/InvitationApi.ts
+++ b/src/apis/InvitationApi.ts
@@ -25,6 +25,7 @@ export class InvitationApi extends AbstractApi {
   }
 
   public async revokeInvitation(invitationId: string): Promise<Invitation> {
+    this.requireId(invitationId);
     return this._restClient.makeRequest({
       method: 'post',
       path: `${basePath}/${invitationId}/revoke`,

--- a/src/apis/SessionApi.ts
+++ b/src/apis/SessionApi.ts
@@ -18,6 +18,7 @@ export class SessionApi extends AbstractApi {
   }
 
   public async getSession(sessionId: string): Promise<Session> {
+    this.requireId(sessionId);
     return this._restClient.makeRequest({
       method: 'get',
       path: `/sessions/${sessionId}`,
@@ -25,6 +26,7 @@ export class SessionApi extends AbstractApi {
   }
 
   public async revokeSession(sessionId: string): Promise<Session> {
+    this.requireId(sessionId);
     return this._restClient.makeRequest({
       method: 'post',
       path: `/sessions/${sessionId}/revoke`,
@@ -35,6 +37,7 @@ export class SessionApi extends AbstractApi {
     sessionId: string,
     token: string
   ): Promise<Session> {
+    this.requireId(sessionId);
     return this._restClient.makeRequest({
       method: 'post',
       path: `/sessions/${sessionId}/verify`,

--- a/src/apis/UserApi.ts
+++ b/src/apis/UserApi.ts
@@ -36,6 +36,7 @@ export class UserApi extends AbstractApi {
   }
 
   public async getUser(userId: string): Promise<User> {
+    this.requireId(userId);
     return this._restClient.makeRequest({
       method: 'get',
       path: `/users/${userId}`,
@@ -46,8 +47,9 @@ export class UserApi extends AbstractApi {
     userId: string,
     params: UserParams = {}
   ): Promise<User> {
-    // The Clerk server API requires metadata fields to be stringified
+    this.requireId(userId);
 
+    // The Clerk server API requires metadata fields to be stringified
     if (params.publicMetadata && !(typeof params.publicMetadata == 'string')) {
       params.publicMetadata = JSON.stringify(params.publicMetadata);
     }
@@ -67,6 +69,7 @@ export class UserApi extends AbstractApi {
   }
 
   public async deleteUser(userId: string): Promise<User> {
+    this.requireId(userId);
     return this._restClient.makeRequest({
       method: 'delete',
       path: `/users/${userId}`,


### PR DESCRIPTION
Whenever we fetch a single request, we need to check that the provided
ID is valid and not let the request go through if the ID is blank.
Since we generate the request endpoints (path) dynamically, we have to
guarantee ID existence.
As an example, let's say we want to fetch a single user and provide a
blank id (''). The generated path will be '/users/' + ''. If this
request goes through, it will fetch the list of users instead.

Added a validateId() protected function in AbstractApi and included the
check in all single resource fetching methods in the SDK.