### PR TITLE
Added missing `createUser` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ the <a href="https://docs.clerk.dev/reference/backend-api-reference" target="_bl
   - [User operations](#user-operations)
     - [getUserList()](#getuserlist)
     - [getUser(userId)](#getuseruserid)
+    - [createUser(params)](#updateuseruserid-params)
     - [updateUser(userId, params)](#updateuseruserid-params)
     - [deleteUser(userId)](#deleteuseruserid)
   - [Email operations](#email-operations)
@@ -442,6 +443,27 @@ const userId = 'my-user-id';
 const user = await clerk.users.getUser(userId);
 ```
 
+#### createUser(params)
+
+Creates a new user and returns that user.
+
+```ts
+const params = { firstName = 'John', lastName: 'Wick' }; // See below for all supported keys
+const user = await clerk.users.createUser(params);
+```
+
+Supported user attributes for update are:
+
+|       Attribute       |        Data type        |
+| :-------------------: | :---------------------: |
+|       firstName       |         string          |
+|       lastName        |         string          |
+|       password        |         string          |
+| primaryEmailAddressID |         string          |
+| primaryPhoneNumberID  |         string          |
+|    publicMetadata     | Record<string, unknown> |
+|    privateMetadata    | Record<string, unknown> |
+
 #### updateUser(userId, params)
 
 Updates a user with a given id with attribute values provided in a params object.
@@ -451,7 +473,7 @@ The provided id must be valid, otherwise an error will be thrown.
 ```ts
 const userId = 'my-user-id';
 const params = { firstName = 'John', lastName: 'Wick' }; // See below for all supported keys
-const user = await clerk.users.update(userId, params);
+const user = await clerk.users.updateUser(userId, params);
 ```
 
 Supported user attributes for update are:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the <a href="https://docs.clerk.dev/reference/backend-api-reference" target="_bl
   - [User operations](#user-operations)
     - [getUserList()](#getuserlist)
     - [getUser(userId)](#getuseruserid)
-    - [createUser(params)](#updateuseruserid-params)
+    - [createUser(params)](#createuserparams)
     - [updateUser(userId, params)](#updateuseruserid-params)
     - [deleteUser(userId)](#deleteuseruserid)
   - [Email operations](#email-operations)

--- a/src/apis/UserApi.ts
+++ b/src/apis/UserApi.ts
@@ -27,6 +27,16 @@ interface UserListParams {
 }
 
 export class UserApi extends AbstractApi {
+  private stringifyMetadata(metadata: Record<string, unknown> | string): string {
+    // The Clerk server API requires metadata fields to be stringified
+    // If not already a string, stringify it
+    if (metadata && !(typeof metadata == 'string')) {
+      return JSON.stringify(metadata);
+    } else {
+      return metadata;
+    }
+  }
+
   public async getUserList(params: UserListParams = {}): Promise<Array<User>> {
     return this._restClient.makeRequest({
       method: 'get',
@@ -50,20 +60,35 @@ export class UserApi extends AbstractApi {
     this.requireId(userId);
 
     // The Clerk server API requires metadata fields to be stringified
-    if (params.publicMetadata && !(typeof params.publicMetadata == 'string')) {
-      params.publicMetadata = JSON.stringify(params.publicMetadata);
+    if (params.publicMetadata) {
+      params.publicMetadata = this.stringifyMetadata(params.publicMetadata);
     }
 
-    if (
-      params.privateMetadata &&
-      !(typeof params.privateMetadata == 'string')
-    ) {
-      params.privateMetadata = JSON.stringify(params.privateMetadata);
+    if (params.privateMetadata) {
+      params.privateMetadata = this.stringifyMetadata(params.privateMetadata);
     }
 
     return this._restClient.makeRequest({
       method: 'patch',
       path: `/users/${userId}`,
+      bodyParams: params,
+    });
+  }
+
+  public async createUser(
+    params: UserParams = {}
+  ): Promise<User> {
+    if (params.publicMetadata) {
+      params.publicMetadata = this.stringifyMetadata(params.publicMetadata);
+    }
+
+    if (params.privateMetadata) {
+      params.privateMetadata = this.stringifyMetadata(params.privateMetadata);
+    }
+
+    return this._restClient.makeRequest({
+      method: 'post',
+      path: `/users`,
       bodyParams: params,
     });
   }


### PR DESCRIPTION
The Clerk API has an endpoint to create a new user but the matching `createUser` function is currently missing. This PR adds it and updates the documentation accordingly.