### PR TITLE
Proper encoding of request body parameters

### DIFF
--- a/src/__tests__/apis/EmailApi.test.ts
+++ b/src/__tests__/apis/EmailApi.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import snakecaseKeys from 'snakecase-keys';
+import querystring from 'querystring';
 import { emails, Email } from '../../index';
 
 test('createEmail() sends an email', async () => {
@@ -9,14 +10,14 @@ test('createEmail() sends an email', async () => {
   const body =
     'Click <a href="https://www.knowyourmeme.com/">here</a> to see your most recent transactions.';
 
-  const encodedBody = new URLSearchParams(
+  const encodedBody = querystring.stringify(
     snakecaseKeys({
       fromEmailName,
       emailAddressId,
       subject,
       body,
     })
-  ).toString();
+  );
 
   nock('https://api.clerk.dev')
     .post('/v1/emails', encodedBody)

--- a/src/__tests__/apis/SMSMessageApi.test.ts
+++ b/src/__tests__/apis/SMSMessageApi.test.ts
@@ -1,14 +1,15 @@
 import nock from 'nock';
 import snakecaseKeys from 'snakecase-keys';
+import querystring from 'querystring';
 import { smsMessages, SMSMessage } from '../../index';
 
 test('createSMSMessage() sends an SMS message', async () => {
   const phoneNumberId = 'idn_random';
   const message = 'Press F to pay pespects';
 
-  const encodedBody = new URLSearchParams(
+  const encodedBody = querystring.stringify(
     snakecaseKeys({ phoneNumberId, message })
-  ).toString();
+  );
 
   nock('https://api.clerk.dev')
     .post('/v1/sms_messages', encodedBody)

--- a/src/utils/RestClient.ts
+++ b/src/utils/RestClient.ts
@@ -59,14 +59,16 @@ export default class RestClient {
     };
 
     if (requestOptions.bodyParams) {
-      gotOptions['form'] = snakecaseKeys(requestOptions.bodyParams);
+      gotOptions['body'] = querystring.stringify(
+        snakecaseKeys(requestOptions.bodyParams)
+      );
     }
 
     // TODO improve error handling
     return got(url, gotOptions)
-      .then(data =>
+      .then((data) =>
         gotOptions.responseType === 'json' ? deserialize(data.body) : data.body
       )
-      .catch(error => handleError(error));
+      .catch((error) => handleError(error));
   }
 }


### PR DESCRIPTION
In order to support complex data structures in request parameters, we have to change the way we encode the request body payload.

Added code in order to stringify request bodies. We are now able to support objects and arrays in request body payloads.