### PR TITLE
fix: Respect httpOptions and add the correct type

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "camelcase-keys": "^6.2.2",
     "cookies": "^0.8.0",
+    "deepmerge": "^4.2.2",
     "got": "^11.8.2",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^2.0.4",

--- a/src/Clerk.ts
+++ b/src/Clerk.ts
@@ -22,6 +22,7 @@ import { Session } from './resources/Session';
 
 import { ClerkServerError } from './utils/Errors';
 import { SupportMessages } from './constants/SupportMessages';
+import type { OptionsOfUnknownResponseBody } from 'got';
 
 const defaultApiKey = process.env.CLERK_API_KEY || '';
 const defaultApiVersion = process.env.CLERK_API_VERSION || 'v1';
@@ -65,7 +66,7 @@ export default class Clerk {
     apiKey?: string;
     serverApiUrl?: string;
     apiVersion?: string;
-    httpOptions?: object;
+    httpOptions?: OptionsOfUnknownResponseBody;
     jwksCacheMaxAge?: number;
   } = {}) {
     if (!apiKey) {
@@ -113,7 +114,7 @@ export default class Clerk {
     this._restClient.apiVersion = value;
   }
 
-  set httpOptions(value: object) {
+  set httpOptions(value: OptionsOfUnknownResponseBody) {
     this._restClient.httpOptions = value;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import type { OptionsOfUnknownResponseBody } from 'got';
 import Clerk from './instance';
 
 const singletonInstance = Clerk.getInstance();
@@ -88,6 +89,6 @@ export function setClerkApiVersion(value: string) {
   Clerk.getInstance().apiVersion = value;
 }
 
-export function setClerkHttpOptions(value: object) {
+export function setClerkHttpOptions(value: OptionsOfUnknownResponseBody) {
   Clerk.getInstance().httpOptions = value;
 }


### PR DESCRIPTION
## Issue

The previous implementation of httpOptions override would not work as the spread operator would override the headers object leading to unauthorized responses.

```ts
    const gotOptions: any = {
      method: requestOptions.method,
      responseType: requestOptions.responseType || 'json',
      headers: {
        Authorization: `Bearer ${this.apiKey}`,
        'Content-type': contentType,
        'user-agent': userAgent,
      },
      ...this.httpOptions,
    };
```

The new implementation is using `deepmerge` so the options can be merged deeply without unexpected overrides. Additionally the "set" attributes are getting a priority over the user supplied ones. That prevents the issue of overriding the `Authorization` header or other required by us.

Notes:
- The httpOptions type has been set properly to provide autocompletion on the available options.

**Before**
![optionsis](https://user-images.githubusercontent.com/15251081/149494162-580b49de-4d79-41a8-9b71-94c46ee7984a.gif)


**After:**
![options](https://user-images.githubusercontent.com/15251081/149494098-73855235-3ae0-43f5-86c5-5a7f70a3d240.gif)

