### PR TITLE
fix: Make next argument optional for usage as middleware function wit…

### DIFF
--- a/src/Clerk.ts
+++ b/src/Clerk.ts
@@ -460,7 +460,7 @@ export default class Clerk {
     return async (
       req: WithSessionProp<Request> | WithSessionClaimsProp<Request>,
       res: Response,
-      next: NextFunction
+      next?: NextFunction
     ) => {
       try {
         await this._runMiddleware(


### PR DESCRIPTION
## Description

Allow middleware as function outside of exports.

In both express and Next.js middleware exports may or may not receive a `next` argument. In the case of middleware-as-function, our types could be lax on the usage of the `next` argument.

### Example use-case:

Some middleware function definition outside of module.exports:
```ts
export const func = withSession((req, res) => { ... }); 
```

api/some.ts
```ts
export default async (req: WithSessionProp<any>, res: any) => {
  res.statusCode = 200;
  // TS would complain for that
  // Even if the usual case would be to chain directly. 
  await func(req, res);
  res.end();
};
```

