### PR TITLE
fix: Don't allow algorithm selection for verifyToken() utility

### DIFF
--- a/src/Clerk.ts
+++ b/src/Clerk.ts
@@ -187,10 +187,7 @@ export default class Clerk {
     return decoded as JwtPayload;
   }
 
-  async verifyToken(
-    token: string,
-    algorithms: string[] = ['RS256']
-  ): Promise<JwtPayload> {
+  async verifyToken(token: string): Promise<JwtPayload> {
     const decoded = jwt.decode(token, { complete: true });
     if (!decoded) {
       throw new Error(`Failed to verify token: ${token}`);
@@ -198,7 +195,7 @@ export default class Clerk {
 
     const key = await this._jwksClient.getSigningKey(decoded.header.kid);
     const verified = jwt.verify(token, key.getPublicKey(), {
-      algorithms: algorithms as jwt.Algorithm[],
+      algorithms: ['RS256'],
     });
 
     if(typeof verified === 'string' || !verified.iss){


### PR DESCRIPTION
Remove the ability to select the signing algorithm for clerk.VerifyToken() utility as it's not applicable. 
Clerk session tokens are using RS256 as their signing algorithm, thus any other algorithm will cause the function to fail and throw an error